### PR TITLE
Allow disabling the Protocol Builder

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -28,6 +28,7 @@ FRONTEND_AUTH_CALLBACK = environ.get('FRONTEND_AUTH_CALLBACK', default="http://l
 SWAGGER_AUTH_KEY = environ.get('SWAGGER_AUTH_KEY', default="SWAGGER")
 
 # %s/%i placeholders expected for uva_id and study_id in various calls.
+PB_ENABLED = environ.get('PB_ENABLED', default=True)
 PB_BASE_URL = environ.get('PB_BASE_URL', default="http://localhost:5001/pb/")
 PB_USER_STUDIES_URL = environ.get('PB_USER_STUDIES_URL', default=PB_BASE_URL + "user_studies?uva_id=%s")
 PB_INVESTIGATORS_URL = environ.get('PB_INVESTIGATORS_URL', default=PB_BASE_URL + "investigators?studyid=%i")

--- a/config/testing.py
+++ b/config/testing.py
@@ -6,6 +6,7 @@ DEVELOPMENT = True
 TESTING = True
 SQLALCHEMY_DATABASE_URI = "postgresql://crc_user:crc_pass@localhost:5432/crc_test"
 TOKEN_AUTH_SECRET_KEY = "Shhhh!!! This is secret!  And better darn well not show up in prod."
+PB_ENABLED = False
 
 print('### USING TESTING CONFIG: ###')
 print('SQLALCHEMY_DATABASE_URI = ', SQLALCHEMY_DATABASE_URI)

--- a/crc/api.yml
+++ b/crc/api.yml
@@ -110,6 +110,19 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Study"
+  /study-files:
+    get:
+      operationId: crc.api.study.all_studies_and_files
+      summary: Provides a list of studies with submitted files
+      tags:
+        - Studies
+      responses:
+        '200':
+          description: An array of studies, with submitted files, ordered by the last modified date.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Study"
   /study/{study_id}:
     parameters:
       - name: study_id

--- a/crc/api.yml
+++ b/crc/api.yml
@@ -156,26 +156,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Study"
-  /study-update/{study_id}:
-    post:
-      operationId: crc.api.study.post_update_study_from_protocol_builder
-      summary: If the study is up-to-date with Protocol Builder, returns a 304 Not Modified. If out of date, return a 202 Accepted and study state changes to updating.
-      tags:
-        - Study Status
-      parameters:
-        - name: study_id
-          in: path
-          required: true
-          description: The id of the study that should be checked for updates.
-          schema:
-            type: integer
-            format: int32
-      responses:
-        '304':
-          description: Study is currently up to date and does not need to be reloaded from Protocol Builder
-        '202':
-          description: Request accepted, will preform an update. Study state set to "updating"
-
   /workflow-specification:
     get:
       operationId: crc.api.workflow.all_specifications

--- a/crc/api/study.py
+++ b/crc/api/study.py
@@ -3,7 +3,9 @@ from sqlalchemy.exc import IntegrityError
 
 from crc import session
 from crc.api.common import ApiError, ApiErrorSchema
-from crc.models.study import StudySchema, StudyModel, Study
+from crc.models.protocol_builder import ProtocolBuilderStatus, ProtocolBuilderStudy
+from crc.models.study import StudySchema, StudyFilesSchema, StudyModel, Study
+from crc.services.protocol_builder import ProtocolBuilderService
 from crc.services.study_service import StudyService
 
 
@@ -62,11 +64,8 @@ def all_studies():
 
 def all_studies_and_files():
     """Returns all studies with submitted files"""
-    studies = StudyService.get_studies_for_user(g.user)
-    results = StudySchema(many=True).dump(studies)
+    studies = StudyService.get_studies_with_files()
+    results = StudyFilesSchema(many=True).dump(studies)
     return results
-
-
-
 
 

--- a/crc/api/study.py
+++ b/crc/api/study.py
@@ -1,20 +1,14 @@
-from typing import List
-
-from connexion import NoContent
 from flask import g
 from sqlalchemy.exc import IntegrityError
 
 from crc import session
 from crc.api.common import ApiError, ApiErrorSchema
-from crc.models.protocol_builder import ProtocolBuilderStatus, ProtocolBuilderStudy
 from crc.models.study import StudySchema, StudyModel, Study
-from crc.services.protocol_builder import ProtocolBuilderService
 from crc.services.study_service import StudyService
 
 
 def add_study(body):
-    """This should never get called, and is subject to deprication.  Studies
-    should be added through the protocol builder only."""
+    """Or any study like object. """
     study: Study = StudySchema().load(body)
     study_model = StudyModel(**study.model_args())
     session.add(study_model)
@@ -59,28 +53,18 @@ def delete_study(study_id):
 
 
 def all_studies():
-    """Returns all the studies associated with the current user.  Assures we are
-    in sync with values read in from the protocol builder. """
-    StudyService.synch_all_studies_with_protocol_builder(g.user)
+    """Returns all the studies associated with the current user. """
+    StudyService.synch_with_protocol_builder_if_enabled(g.user)
     studies = StudyService.get_studies_for_user(g.user)
     results = StudySchema(many=True).dump(studies)
     return results
 
 
-def post_update_study_from_protocol_builder(study_id):
-    """Update a single study based on data received from
-    the protocol builder."""
-
-    db_study = session.query(StudyModel).filter_by(study_id=study_id).all()
-    pb_studies: List[ProtocolBuilderStudy] = ProtocolBuilderService.get_studies(g.user.uid)
-    pb_study = next((pbs for pbs in pb_studies if pbs.STUDYID == study_id), None)
-    if pb_study:
-        db_study.update_from_protocol_builder(pb_study)
-    else:
-        db_study.inactive = True
-        db_study.protocol_builder_status = ProtocolBuilderStatus.ABANDONED
-
-    return NoContent, 304
+def all_studies_and_files():
+    """Returns all studies with submitted files"""
+    studies = StudyService.get_studies_for_user(g.user)
+    results = StudySchema(many=True).dump(studies)
+    return results
 
 
 

--- a/crc/models/file.py
+++ b/crc/models/file.py
@@ -6,7 +6,7 @@ from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from sqlalchemy import func, Index
 from sqlalchemy.dialects.postgresql import UUID
 
-from crc import db
+from crc import db, ma
 
 
 class FileType(enum.Enum):
@@ -139,3 +139,9 @@ class LookupDataSchema(SQLAlchemyAutoSchema):
         include_relationships = False
         include_fk = False  # Includes foreign keys
 
+
+class SimpleFileSchema(ma.Schema):
+
+    class Meta:
+        model = FileModel
+        fields = ["name"]

--- a/crc/models/user.py
+++ b/crc/models/user.py
@@ -7,6 +7,12 @@ from crc import db, app
 from crc.api.common import ApiError
 
 
+class Approvals(db.Model):
+    approval_uid = db.Column(db.String, unique=True)
+    workflow_id = db.Column(db.Integer, primary_key=True)
+    workflow_version = db.Column(db.String)
+    is_approved = db.Column(db.Boolean)
+
 class UserModel(db.Model):
     __tablename__ = 'user'
     id = db.Column(db.Integer, primary_key=True)
@@ -18,6 +24,8 @@ class UserModel(db.Model):
     first_name = db.Column(db.String, nullable=True)
     last_name = db.Column(db.String, nullable=True)
     title = db.Column(db.String, nullable=True)
+
+    # Add Department and School
 
 
     def encode_auth_token(self):

--- a/crc/models/workflow.py
+++ b/crc/models/workflow.py
@@ -73,10 +73,12 @@ class WorkflowModel(db.Model):
     bpmn_workflow_json = db.Column(db.JSON)
     status = db.Column(db.Enum(WorkflowStatus))
     study_id = db.Column(db.Integer, db.ForeignKey('study.id'))
+    study = db.relationship("StudyModel", backref='workflow')
     workflow_spec_id = db.Column(db.String, db.ForeignKey('workflow_spec.id'))
     workflow_spec = db.relationship("WorkflowSpecModel")
     spec_version = db.Column(db.String)
     total_tasks = db.Column(db.Integer, default=0)
     completed_tasks = db.Column(db.Integer, default=0)
-#    task_history = db.Column(db.ARRAY(db.String), default=[]) # The history stack of user completed tasks.
     last_updated = db.Column(db.DateTime)
+    # todo: Add a version that represents the files associated with this workflow
+    # version = "32"

--- a/crc/services/study_service.py
+++ b/crc/services/study_service.py
@@ -110,23 +110,29 @@ class StudyService(object):
         """Returns a list of documents related to the study, and any file information
         that is available.."""
 
-        # Get PB required docs
-        try:
-            pb_docs = ProtocolBuilderService.get_required_docs(study_id=study_id)
-        except requests.exceptions.ConnectionError as ce:
-            app.logger.error("Failed to connect to the Protocol Builder - %s" % str(ce))
+        # Get PB required docs, if Protocol Builder Service is enabled.
+        if ProtocolBuilderService.ENABLED:
+            try:
+                pb_docs = ProtocolBuilderService.get_required_docs(study_id=study_id)
+            except requests.exceptions.ConnectionError as ce:
+                app.logger.error("Failed to connect to the Protocol Builder - %s" % str(ce))
+                pb_docs = []
+        else:
             pb_docs = []
 
-        # Loop through all known document types, get the counts for those files, and use pb_docs to mark those required.
+        # Loop through all known document types, get the counts for those files,
+        # and use pb_docs to mark those as required.
         doc_dictionary = FileService.get_reference_data(FileService.DOCUMENT_LIST, 'code', ['id'])
 
         documents = {}
         for code, doc in doc_dictionary.items():
 
-            pb_data = next((item for item in pb_docs if int(item['AUXDOCID']) == int(doc['id'])), None)
-            doc['required'] = False
-            if pb_data:
-                doc['required'] = True
+            if ProtocolBuilderService.ENABLED:
+                pb_data = next((item for item in pb_docs if int(item['AUXDOCID']) == int(doc['id'])), None)
+                doc['required'] = False
+                if pb_data:
+                    doc['required'] = True
+
             doc['study_id'] = study_id
             doc['code'] = code
 
@@ -153,7 +159,6 @@ class StudyService(object):
                     doc['status'] = workflow.status.value
 
             documents[code] = doc
-
         return documents
 
 
@@ -201,9 +206,13 @@ class StudyService(object):
 
 
     @staticmethod
-    def synch_all_studies_with_protocol_builder(user):
+    def synch_with_protocol_builder_if_enabled(user):
         """Assures that the studies we have locally for the given user are
         in sync with the studies available in protocol builder. """
+
+        if not ProtocolBuilderService.ENABLED:
+            return
+
         # Get studies matching this user from Protocol Builder
         pb_studies: List[ProtocolBuilderStudy] = ProtocolBuilderService.get_studies(user.uid)
 

--- a/crc/services/study_service.py
+++ b/crc/services/study_service.py
@@ -33,6 +33,12 @@ class StudyService(object):
         return studies
 
     @staticmethod
+    def get_studies_with_files():
+        """Returns a list of all studies"""
+        db_studies = session.query(StudyModel).all()
+        return db_studies
+
+    @staticmethod
     def get_study(study_id, study_model: StudyModel = None):
         """Returns a study model that contains all the workflows organized by category.
         IMPORTANT:  This is intended to be a lightweight call, it should never involve

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -1,7 +1,9 @@
 # Set environment variable to testing before loading.
 # IMPORTANT - Environment must be loaded before app, models, etc....
-import json
 import os
+os.environ["TESTING"] = "true"
+
+import json
 import unittest
 import urllib.parse
 import datetime
@@ -10,10 +12,6 @@ from crc.models.protocol_builder import ProtocolBuilderStatus
 from crc.models.study import StudyModel
 from crc.services.file_service import FileService
 from crc.services.study_service import StudyService
-from crc.services.workflow_processor import WorkflowProcessor
-
-os.environ["TESTING"] = "true"
-
 from crc.models.file import FileModel, FileDataModel, CONTENT_TYPES
 from crc.models.workflow import WorkflowSpecModel, WorkflowSpecModelSchema, WorkflowModel
 from crc.models.user import UserModel
@@ -31,6 +29,10 @@ class BaseTest(unittest.TestCase):
     """ Great class to inherit from, as it sets up and tears down classes
         efficiently when we have a database in place.
     """
+
+    if not app.config['TESTING']:
+        raise ("INVALID TEST CONFIGURATION. This is almost always in import order issue."
+               "The first class to import in each test should be the base_test.py file.")
 
     auths = {}
     test_uid = "dhf8r"

--- a/tests/data/empty_workflow/empty_workflow.bpmn
+++ b/tests/data/empty_workflow/empty_workflow.bpmn
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1v1rp1q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.3">
+  <bpmn:process id="empty_workflow" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>SequenceFlow_0lvudp8</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_0lvudp8" sourceRef="StartEvent_1" targetRef="EndEvent_0q4qzl9" />
+    <bpmn:endEvent id="EndEvent_0q4qzl9">
+      <bpmn:incoming>SequenceFlow_0lvudp8</bpmn:incoming>
+    </bpmn:endEvent>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="empty_workflow">
+      <bpmndi:BPMNEdge id="SequenceFlow_0lvudp8_di" bpmnElement="SequenceFlow_0lvudp8">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="EndEvent_0q4qzl9_di" bpmnElement="EndEvent_0q4qzl9">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/test_protocol_builder.py
+++ b/tests/test_protocol_builder.py
@@ -1,7 +1,7 @@
 from unittest.mock import patch
 
-from crc.services.protocol_builder import ProtocolBuilderService
 from tests.base_test import BaseTest
+from crc.services.protocol_builder import ProtocolBuilderService
 
 
 class TestProtocolBuilder(BaseTest):
@@ -10,6 +10,7 @@ class TestProtocolBuilder(BaseTest):
 
     @patch('crc.services.protocol_builder.requests.get')
     def test_get_studies(self, mock_get):
+        ProtocolBuilderService.ENABLED = True
         mock_get.return_value.ok = True
         mock_get.return_value.text = self.protocol_builder_response('user_studies.json')
         response = ProtocolBuilderService.get_studies(self.test_uid)
@@ -17,6 +18,7 @@ class TestProtocolBuilder(BaseTest):
 
     @patch('crc.services.protocol_builder.requests.get')
     def test_get_investigators(self, mock_get):
+        ProtocolBuilderService.ENABLED = True
         mock_get.return_value.ok = True
         mock_get.return_value.text = self.protocol_builder_response('investigators.json')
         response = ProtocolBuilderService.get_investigators(self.test_study_id)
@@ -28,6 +30,7 @@ class TestProtocolBuilder(BaseTest):
 
     @patch('crc.services.protocol_builder.requests.get')
     def test_get_required_docs(self, mock_get):
+        ProtocolBuilderService.ENABLED = True
         mock_get.return_value.ok = True
         mock_get.return_value.text = self.protocol_builder_response('required_docs.json')
         response = ProtocolBuilderService.get_required_docs(self.test_study_id)
@@ -37,6 +40,7 @@ class TestProtocolBuilder(BaseTest):
 
     @patch('crc.services.protocol_builder.requests.get')
     def test_get_details(self, mock_get):
+        ProtocolBuilderService.ENABLED = True
         mock_get.return_value.ok = True
         mock_get.return_value.text = self.protocol_builder_response('study_details.json')
         response = ProtocolBuilderService.get_study_details(self.test_study_id)

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -8,6 +8,7 @@ from crc.models.api_models import WorkflowApiSchema, MultiInstanceType, TaskSche
 from crc.models.file import FileModelSchema
 from crc.models.stats import TaskEventModel
 from crc.models.workflow import WorkflowStatus
+from crc.services.protocol_builder import ProtocolBuilderService
 from crc.services.workflow_service import WorkflowService
 from tests.base_test import BaseTest
 
@@ -302,6 +303,9 @@ class TestTasksApi(BaseTest):
 
     @patch('crc.services.protocol_builder.requests.get')
     def test_multi_instance_task(self, mock_get):
+        # Enable the protocol builder.
+        ProtocolBuilderService.ENABLED = True
+
         # This depends on getting a list of investigators back from the protocol builder.
         mock_get.return_value.ok = True
         mock_get.return_value.text = self.protocol_builder_response('investigators.json')

--- a/tests/test_workflow_spec_validation_api.py
+++ b/tests/test_workflow_spec_validation_api.py
@@ -20,21 +20,7 @@ class TestWorkflowSpecValidation(BaseTest):
         json_data = json.loads(rv.get_data(as_text=True))
         return ApiErrorSchema(many=True).load(json_data)
 
-    @patch('crc.services.protocol_builder.ProtocolBuilderService.get_investigators')  # mock_studies
-    @patch('crc.services.protocol_builder.ProtocolBuilderService.get_required_docs')  # mock_docs
-    @patch('crc.services.protocol_builder.ProtocolBuilderService.get_study_details')  # mock_details
-    @patch('crc.services.protocol_builder.ProtocolBuilderService.get_studies')  # mock_studies
-    def test_successful_validation_of_test_workflows(self, mock_studies, mock_details, mock_docs, mock_investigators):
-
-        # Mock Protocol Builder responses
-        studies_response = self.protocol_builder_response('user_studies.json')
-        mock_studies.return_value = ProtocolBuilderStudySchema(many=True).loads(studies_response)
-        details_response = self.protocol_builder_response('study_details.json')
-        mock_details.return_value = json.loads(details_response)
-        docs_response = self.protocol_builder_response('required_docs.json')
-        mock_docs.return_value = json.loads(docs_response)
-        investigators_response = self.protocol_builder_response('investigators.json')
-        mock_investigators.return_value = json.loads(investigators_response)
+    def test_successful_validation_of_test_workflows(self):
 
         self.assertEqual(0, len(self.validate_workflow("parallel_tasks")))
         self.assertEqual(0, len(self.validate_workflow("decision_table")))


### PR DESCRIPTION
PB_ENABLED can be set to false in the configuration (either in a file called instance/config.py, or as an environment variable)

Added a check in the base_test, to assure that we are always running tests with the test configuration, and bail out otherwise.  Setting TESTING=true as an environment variable will get this, but so well the correct ordering of imports. Just be dead certain the first file every test file imports is base_test.py.

Aaron was right, and we call the Protocol Builder in all kinds of awful places.  But we don't do this now.  So Carlos, you should have the ability to reuse a lot of the logic in the study_service now.

I dropped the poorly named "study-update" endpoint completely.  We weren't using it. POST and PUT to Study still work just fine for doing exactly that.

All the tests now run and pass with the Protocol builder disabled. Tests that specifically check PB behavior turn it back on for the test, or mock it out.