### PR TITLE
Fixed ApiError call. Now includes task_id and task_name.

### DIFF
--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -130,7 +130,9 @@ class WorkflowService(object):
             # Assure we have a field type
             if field.type is None:
                 raise ApiError(code='invalid_form_data',
-                               message='Field type is None. A field type must be provided.')
+                               message=f'Type is missing for field "{field.id}". A field type must be provided.',
+                               task_id=task.id,
+                               task_name=task.get_name())
             # Assure field has valid properties
             WorkflowService.check_field_properties(field, task)
 

--- a/tests/workflow/test_workflow_form_field_type.py
+++ b/tests/workflow/test_workflow_form_field_type.py
@@ -10,5 +10,5 @@ class TestFormFieldType(BaseTest):
 
         json_data = json.loads(rv.get_data(as_text=True))
         self.assertEqual(json_data[0]['message'],
-                         'When populating all fields ... Field type is None. A field type must be provided.')
+                         'When populating all fields ... Type is missing for field "name". A field type must be provided.')
         # print('TestFormFieldType: Good Form')


### PR DESCRIPTION
This is a follow-up for ticket 143 about missing field type. The call to ApiError now includes more information about the field and the task.