### PR TITLE
Users cannot upload a workflow_spec_file that already exists. We rais…

### DIFF
--- a/crc/services/file_service.py
+++ b/crc/services/file_service.py
@@ -35,14 +35,22 @@ class FileService(object):
     def add_workflow_spec_file(workflow_spec: WorkflowSpecModel,
                                name, content_type, binary_data, primary=False, is_status=False):
         """Create a new file and associate it with a workflow spec."""
-        file_model = FileModel(
-            workflow_spec_id=workflow_spec.id,
-            name=name,
-            primary=primary,
-            is_status=is_status,
-        )
+        # Raise ApiError if the file already exists
+        if session.query(FileModel)\
+            .filter(FileModel.workflow_spec_id == workflow_spec.id)\
+            .filter(FileModel.name == name).first():
 
-        return FileService.update_file(file_model, binary_data, content_type)
+            raise ApiError(code="Duplicate File",
+                           message='If you want to replace the file, use the update mechanism.')
+        else:
+            file_model = FileModel(
+                workflow_spec_id=workflow_spec.id,
+                name=name,
+                primary=primary,
+                is_status=is_status,
+            )
+
+            return FileService.update_file(file_model, binary_data, content_type)
 
     @staticmethod
     def is_allowed_document(code):

--- a/tests/workflow/test_duplicate_workflow_spec_file.py
+++ b/tests/workflow/test_duplicate_workflow_spec_file.py
@@ -1,0 +1,32 @@
+from tests.base_test import BaseTest
+from crc import session
+from crc.api.common import ApiError
+from crc.models.workflow import WorkflowSpecModel
+from crc.services.file_service import FileService
+
+
+class TestDuplicateWorkflowSpecFile(BaseTest):
+
+    def test_duplicate_workflow_spec_file(self):
+        # We want this to fail.
+        # Users should not be able to upload a file that already exists.
+
+        self.load_example_data()
+        spec = session.query(WorkflowSpecModel).first()
+
+        # Add a file
+        file_model = FileService.add_workflow_spec_file(spec,
+                                                        name="something.png",
+                                                        content_type="text",
+                                                        binary_data=b'1234')
+        self.assertEqual(file_model.name, 'something.png')
+        self.assertEqual(file_model.content_type, 'text')
+
+        # Try to add it again
+        try:
+            FileService.add_workflow_spec_file(spec,
+                                               name="something.png",
+                                               content_type="text",
+                                               binary_data=b'5678')
+        except ApiError as ae:
+            self.assertEqual(ae.message, 'If you want to replace the file, use the update mechanism.')


### PR DESCRIPTION
…e an error that is displayed on the fron end.

We search files with workflow_spec_id and name. 
If a record exists, we raise an ApiError that displays a message in the front end.
Otherwise, create file record as usual