### PR TITLE
Missing form key 163

### DIFF
--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -108,6 +108,12 @@ class WorkflowService(object):
                     task_api = WorkflowService.spiff_task_to_api_task(
                         task,
                         add_docs_and_forms=True)  # Assure we try to process the documentation, and raise those errors.
+                    # make sure forms have a form key
+                    if hasattr(task_api, 'form') and task_api.form is not None and task_api.form.key == '':
+                        raise ApiError(code='missing_form_key',
+                                       message='Forms must include a Form Key.',
+                                       task_id=task.id,
+                                       task_name=task.get_name())
                     WorkflowService.populate_form_with_random_data(task, task_api, required_only)
                     processor.complete_task(task)
             except WorkflowException as we:

--- a/tests/data/ldap_script/ldap_script.bpmn
+++ b/tests/data/ldap_script/ldap_script.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0y2dq4f" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.3">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0y2dq4f" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="Process_0tad5ma" name="Set Recipients" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1synsig</bpmn:outgoing>
@@ -28,7 +28,7 @@ me = ldap()</bpmn:script>
       <bpmn:outgoing>Flow_08n2npe</bpmn:outgoing>
     </bpmn:userTask>
     <bpmn:sequenceFlow id="Flow_11e7jgz" sourceRef="Activity_0f78ek5" targetRef="Event_0izrcj4" />
-    <bpmn:userTask id="Activity_0f78ek5" name="Read UIDs">
+    <bpmn:userTask id="Activity_0f78ek5" name="Read UIDs" camunda:formKey="ReadUIDs">
       <bpmn:incoming>Flow_1xlrgne</bpmn:incoming>
       <bpmn:outgoing>Flow_11e7jgz</bpmn:outgoing>
     </bpmn:userTask>

--- a/tests/data/missing_form_key/missing_form_key.bpmn
+++ b/tests/data/missing_form_key/missing_form_key.bpmn
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1v1rp1q" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="MissingFormID" name="Missing Form ID" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1dl9zdu</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:endEvent id="EndEvent_0q4qzl9">
+      <bpmn:incoming>SequenceFlow_02vev7n</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="SequenceFlow_02vev7n" sourceRef="Task_HelloWorld" targetRef="EndEvent_0q4qzl9" />
+    <bpmn:sequenceFlow id="Flow_1dl9zdu" sourceRef="StartEvent_1" targetRef="Activity_GetName" />
+    <bpmn:sequenceFlow id="Flow_1iohvj2" sourceRef="Activity_GetName" targetRef="Task_HelloWorld" />
+    <bpmn:userTask id="Activity_GetName" name="Get Name">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="name" label="Please enter your name" type="string" defaultValue="World" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1dl9zdu</bpmn:incoming>
+      <bpmn:outgoing>Flow_1iohvj2</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:manualTask id="Task_HelloWorld" name="Hello World">
+      <bpmn:documentation>&lt;h1&gt;Hello {{ name }}&lt;/h1&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_1iohvj2</bpmn:incoming>
+      <bpmn:outgoing>SequenceFlow_02vev7n</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="MissingFormID">
+      <bpmndi:BPMNEdge id="SequenceFlow_02vev7n_di" bpmnElement="SequenceFlow_02vev7n">
+        <di:waypoint x="580" y="117" />
+        <di:waypoint x="642" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1dl9zdu_di" bpmnElement="Flow_1dl9zdu">
+        <di:waypoint x="188" y="117" />
+        <di:waypoint x="280" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1iohvj2_di" bpmnElement="Flow_1iohvj2">
+        <di:waypoint x="380" y="117" />
+        <di:waypoint x="480" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="EndEvent_0q4qzl9_di" bpmnElement="EndEvent_0q4qzl9">
+        <dc:Bounds x="642" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="152" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1gbakdp_di" bpmnElement="Activity_GetName">
+        <dc:Bounds x="280" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11m46jy_di" bpmnElement="Task_HelloWorld">
+        <dc:Bounds x="480" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/workflow/test_workflow_missing_form_key.py
+++ b/tests/workflow/test_workflow_missing_form_key.py
@@ -1,0 +1,13 @@
+from tests.base_test import BaseTest
+import json
+
+
+class TestMissingFormKey(BaseTest):
+
+    def test_missing_form_key(self):
+
+        spec_model = self.load_test_spec('missing_form_key')
+        rv = self.app.get('/v1.0/workflow-specification/%s/validate' % spec_model.id, headers=self.logged_in_headers())
+        json_data = json.loads(rv.get_data(as_text=True))
+        self.assertIn('code', json_data[0])
+        self.assertEqual('missing_form_key', json_data[0]['code'])


### PR DESCRIPTION
When validating, we now make sure workflow forms have a form key. If not, we raise an ApiError.