### PR TITLE
Cancellations 137

### DIFF
--- a/crc/api/study.py
+++ b/crc/api/study.py
@@ -9,6 +9,7 @@ from crc.models.protocol_builder import ProtocolBuilderStatus
 from crc.models.study import Study, StudyEvent, StudyEventType, StudyModel, StudySchema, StudyForUpdateSchema, StudyStatus
 from crc.services.study_service import StudyService
 from crc.services.user_service import UserService
+from crc.services.workflow_service import WorkflowService
 
 
 def add_study(body):
@@ -63,6 +64,10 @@ def update_study(study_id, body):
 
     session.add(study_model)
     session.commit()
+
+    if status == StudyStatus.abandoned or status == StudyStatus.hold:
+        WorkflowService.process_workflows_for_cancels(study_id)
+
     # Need to reload the full study to return it to the frontend
     study = StudyService.get_study(study_id)
     return StudySchema().dump(study)

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -115,7 +115,7 @@ def restart_workflow(workflow_id, clear_data=False):
     """Restart a workflow with the latest spec.
        Clear data allows user to restart the workflow without previous data."""
     workflow_model: WorkflowModel = session.query(WorkflowModel).filter_by(id=workflow_id).first()
-    WorkflowProcessor.reset(workflow_model, clear_data=clear_data)
+    WorkflowProcessor(workflow_model).reset(workflow_model, clear_data=clear_data)
     return get_workflow(workflow_model.id)
 
 

--- a/crc/services/workflow_processor.py
+++ b/crc/services/workflow_processor.py
@@ -196,10 +196,10 @@ class WorkflowProcessor(object):
         else:
             self.is_latest_spec = False
 
-    @classmethod
-    def reset(cls, workflow_model, clear_data=False):
+    def reset(self, workflow_model, clear_data=False):
         print('WorkflowProcessor: reset: ')
 
+        self.cancel_notify()
         workflow_model.bpmn_workflow_json = None
         if clear_data:
             # Clear form_data from task_events
@@ -209,7 +209,7 @@ class WorkflowProcessor(object):
                 task_event.form_data = {}
                 session.add(task_event)
         session.commit()
-        return cls(workflow_model)
+        return self.__init__(workflow_model)
 
     def __get_bpmn_workflow(self, workflow_model: WorkflowModel, spec: WorkflowSpec, validate_only=False):
         if workflow_model.bpmn_workflow_json:

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -704,5 +704,10 @@ class WorkflowService(object):
 
         return data
 
-
-
+    @staticmethod
+    def process_workflows_for_cancels(study_id):
+        workflows = db.session.query(WorkflowModel).filter_by(study_id=study_id).all()
+        for workflow in workflows:
+            if workflow.status == WorkflowStatus.user_input_required or workflow.status == WorkflowStatus.waiting:
+                processor = WorkflowProcessor(workflow)
+                processor.reset(workflow)

--- a/tests/data/study_cancellations/study_cancellations.bpmn
+++ b/tests/data/study_cancellations/study_cancellations.bpmn
@@ -1,0 +1,148 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0a9entn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="Process_1dagb7t" name="TestMessage" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1" name="Start">
+      <bpmn:outgoing>Flow_0xym55y</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_16q1uec" name="TestMessageFlow" sourceRef="Event_TokenReset" targetRef="Activity_TestMessage" />
+    <bpmn:scriptTask id="Activity_TestMessage" name="Test Message" camunda:resultVariable="test_message">
+      <bpmn:incoming>Flow_16q1uec</bpmn:incoming>
+      <bpmn:script>update_study("title:'New Title'")
+print('New Title')</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_0xym55y" sourceRef="StartEvent_1" targetRef="Activity_Hello" />
+    <bpmn:userTask id="Activity_HowMany" name="HowMany" camunda:formKey="HowMany">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="how_many" label="How many?" type="long" defaultValue="1" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1e9j7mj</bpmn:incoming>
+      <bpmn:outgoing>Flow_07i0gvv</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_07i0gvv" sourceRef="Activity_HowMany" targetRef="Activity_Modify" />
+    <bpmn:boundaryEvent id="Event_TokenReset" name="TokenReset" attachedToRef="Activity_HowMany">
+      <bpmn:outgoing>Flow_16q1uec</bpmn:outgoing>
+      <bpmn:cancelEventDefinition id="CancelEventDefinition_1d5hszc" />
+    </bpmn:boundaryEvent>
+    <bpmn:manualTask id="Activity_Hello" name="Hello">
+      <bpmn:documentation>&lt;H1&gt;Hello&lt;/H1&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_0xym55y</bpmn:incoming>
+      <bpmn:outgoing>Flow_1e9j7mj</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_1e9j7mj" sourceRef="Activity_Hello" targetRef="Activity_HowMany" />
+    <bpmn:endEvent id="Event_10cp2vv">
+      <bpmn:incoming>Flow_0rus4fi</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_0rus4fi" sourceRef="Activity_GoodBye" targetRef="Event_10cp2vv" />
+    <bpmn:manualTask id="Activity_GoodBye" name="Good Bye">
+      <bpmn:documentation>&lt;H1&gt;Good Bye&lt;/H1&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_0f79pbo</bpmn:incoming>
+      <bpmn:outgoing>Flow_0rus4fi</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:userTask id="Activity_Modify" name="Modify" camunda:formKey="FormModify">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="modify" label="Modify Data?" type="boolean" defaultValue="True" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_07i0gvv</bpmn:incoming>
+      <bpmn:outgoing>Flow_0f79pbo</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0f79pbo" sourceRef="Activity_Modify" targetRef="Activity_GoodBye" />
+    <bpmn:boundaryEvent id="Event_TokenReset2" name="TokenReset" attachedToRef="Activity_Modify">
+      <bpmn:outgoing>Flow_13xidv2</bpmn:outgoing>
+      <bpmn:cancelEventDefinition id="CancelEventDefinition_1r2giko" />
+    </bpmn:boundaryEvent>
+    <bpmn:sequenceFlow id="Flow_13xidv2" name="CancelMessageFlow" sourceRef="Event_TokenReset2" targetRef="Activity_CancelMessage" />
+    <bpmn:scriptTask id="Activity_CancelMessage" name="Cancel Message" camunda:resultVariable="cancel_message">
+      <bpmn:documentation>&lt;H1&gt;Cancel Message&lt;/H1&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_13xidv2</bpmn:incoming>
+      <bpmn:script>update_study("title:'Second Title'")
+print('Second Title')</bpmn:script>
+    </bpmn:scriptTask>
+  </bpmn:process>
+  <bpmn:message id="Message_0iyvlbz" name="token_reset" />
+  <bpmn:message id="Message_1ow6ruy" name="Message_00ldv4i" />
+  <bpmn:signal id="Signal_1fbgshz" name="token_reset" />
+  <bpmn:message id="Message_1czi5ye" name="token_reset" />
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_1dagb7t">
+      <bpmndi:BPMNEdge id="Flow_1e9j7mj_di" bpmnElement="Flow_1e9j7mj">
+        <di:waypoint x="370" y="118" />
+        <di:waypoint x="441" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07i0gvv_di" bpmnElement="Flow_07i0gvv">
+        <di:waypoint x="541" y="118" />
+        <di:waypoint x="627" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_16q1uec_di" bpmnElement="Flow_16q1uec">
+        <di:waypoint x="491" y="176" />
+        <di:waypoint x="491" y="223" />
+        <di:waypoint x="490" y="223" />
+        <di:waypoint x="490" y="269" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="496" y="196" width="89" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0f79pbo_di" bpmnElement="Flow_0f79pbo">
+        <di:waypoint x="727" y="118" />
+        <di:waypoint x="797" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0rus4fi_di" bpmnElement="Flow_0rus4fi">
+        <di:waypoint x="897" y="118" />
+        <di:waypoint x="969" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13xidv2_di" bpmnElement="Flow_13xidv2">
+        <di:waypoint x="687" y="176" />
+        <di:waypoint x="687" y="269" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="694" y="226" width="86" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0xym55y_di" bpmnElement="Flow_0xym55y">
+        <di:waypoint x="189" y="118" />
+        <di:waypoint x="270" y="118" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="Activity_0bieozg_di" bpmnElement="Activity_TestMessage">
+        <dc:Bounds x="440" y="269" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hkt70o_di" bpmnElement="Activity_HowMany">
+        <dc:Bounds x="441" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_00p1v49_di" bpmnElement="Activity_Modify">
+        <dc:Bounds x="627" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0n39q5x_di" bpmnElement="Activity_GoodBye">
+        <dc:Bounds x="797" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10cp2vv_di" bpmnElement="Event_10cp2vv">
+        <dc:Bounds x="969" y="100" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0a9mhpp_di" bpmnElement="Activity_CancelMessage">
+        <dc:Bounds x="637" y="269" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1e3uaeb_di" bpmnElement="Activity_Hello">
+        <dc:Bounds x="270" y="78" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="153" y="100" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="159" y="143" width="24" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1yxxtrb_di" bpmnElement="Event_TokenReset">
+        <dc:Bounds x="473" y="140" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="501" y="174" width="59" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_10t25ob_di" bpmnElement="Event_TokenReset2">
+        <dc:Bounds x="669" y="140" width="36" height="36" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="714" y="167" width="59" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/study/test_study_cancellations.py
+++ b/tests/study/test_study_cancellations.py
@@ -1,0 +1,107 @@
+from tests.base_test import BaseTest
+
+from crc import session
+from crc.models.study import StudyModel, StudySchema
+from crc.models.workflow import WorkflowModel, WorkflowSpecModel
+
+import json
+
+
+class TestStudyCancellations(BaseTest):
+
+    def update_study_status(self, study, study_schema):
+        put_response = self.app.put('/v1.0/study/%i' % study.id,
+                                    content_type="application/json",
+                                    headers=self.logged_in_headers(),
+                                    data=json.dumps(study_schema))
+        self.assert_success(put_response)
+
+        # The error happened when the dashboard reloaded,
+        # in particular, when we got the studies for the user
+        api_response = self.app.get('/v1.0/study', headers=self.logged_in_headers(), content_type="application/json")
+        self.assert_success(api_response)
+
+        study_result = session.query(StudyModel).filter(StudyModel.id == study.id).first()
+        return study_result
+
+    def put_study_on_hold(self, study_id):
+        study = session.query(StudyModel).filter_by(id=study_id).first()
+
+        study_schema = StudySchema().dump(study)
+        study_schema['status'] = 'hold'
+        study_schema['comment'] = 'This is my hold comment'
+
+        self.update_study_status(study, study_schema)
+
+        study_result = session.query(StudyModel).filter(StudyModel.id == study_id).first()
+        return study_result
+
+    def load_workflow(self):
+        self.load_example_data()
+        workflow = self.create_workflow('study_cancellations')
+        study_id = workflow.study_id
+        return workflow, study_id
+
+    def get_first_task(self, workflow):
+        workflow_api = self.get_workflow_api(workflow)
+        first_task = workflow_api.next_task
+        self.assertEqual('Activity_Hello', first_task.name)
+        return workflow_api, first_task
+
+    def get_second_task(self, workflow):
+        workflow_api = self.get_workflow_api(workflow)
+        second_task = workflow_api.next_task
+        self.assertEqual('Activity_HowMany', second_task.name)
+        return workflow_api, second_task
+
+    def get_third_task(self, workflow):
+        workflow_api = self.get_workflow_api(workflow)
+        third_task = workflow_api.next_task
+        self.assertEqual('Activity_Modify', third_task.name)
+        return workflow_api, third_task
+
+    def test_before_cancel(self):
+
+        workflow, study_id = self.load_workflow()
+        self.get_first_task(workflow)
+
+        study_result = self.put_study_on_hold(study_id)
+        self.assertEqual('Beer consumption in the bipedal software engineer', study_result.title)
+
+    def test_first_cancel(self):
+        workflow, study_id = self.load_workflow()
+        workflow_api, first_task = self.get_first_task(workflow)
+
+        self.complete_form(workflow_api, first_task, {})
+
+        study_result = self.put_study_on_hold(study_id)
+        self.assertEqual('New Title', study_result.title)
+
+    def test_second_cancel(self):
+
+        workflow, study_id = self.load_workflow()
+        workflow_api, first_task = self.get_first_task(workflow)
+
+        self.complete_form(workflow_api, first_task, {})
+
+        workflow_api, next_task = self.get_second_task(workflow)
+        self.complete_form(workflow_api, next_task, {'how_many': 3})
+
+        study_result = self.put_study_on_hold(study_id)
+        self.assertEqual('Second Title', study_result.title)
+
+    def test_after_cancel(self):
+
+        workflow, study_id = self.load_workflow()
+        workflow_api, first_task = self.get_first_task(workflow)
+
+        self.complete_form(workflow_api, first_task, {})
+
+        workflow_api, second_task = self.get_second_task(workflow)
+        self.complete_form(workflow_api, second_task, {'how_many': 3})
+
+        workflow_api, third_task = self.get_third_task(workflow)
+        self.complete_form(workflow_api, third_task, {})
+
+        study_result = self.put_study_on_hold(study_id)
+        self.assertEqual('Beer consumption in the bipedal software engineer', study_result.title)

--- a/tests/test_lookup_service.py
+++ b/tests/test_lookup_service.py
@@ -54,7 +54,8 @@ class TestLookupService(BaseTest):
 
         # restart the workflow, so it can pick up the changes.
 
-        processor = WorkflowProcessor.reset(workflow)
+        processor = WorkflowProcessor(workflow)
+        processor.reset(workflow)
         workflow = processor.workflow_model
 
         LookupService.lookup(workflow, "sponsor", "sam", limit=10)

--- a/tests/workflow/test_workflow_processor.py
+++ b/tests/workflow/test_workflow_processor.py
@@ -279,7 +279,7 @@ class TestWorkflowProcessor(BaseTest):
         self.assertFalse(processor2.is_latest_spec) # Still at version 1.
 
         # Do a hard reset, which should bring us back to the beginning, but retain the data.
-        WorkflowProcessor.reset(processor2.workflow_model)
+        processor2.reset(processor2.workflow_model)
         processor3 = WorkflowProcessor(processor.workflow_model)
         processor3.do_engine_steps()
         self.assertEqual("Step 1", processor3.next_task().task_spec.description)


### PR DESCRIPTION
When a study is put on hold or abandoned, we now reset in_progress workflows and call any pending cancel_notify events.

While working on this ticket, we noticed that WorkflowProcessor.reset wasn't calling cancel_notify events like we do with set_token. We fix that and add some tests to test_workflow_restart

 - created method services.workflow_service.process_workflows_for_cancels. It loops through workflows and resets them if they are in progress
 - in api.study.update_study we call the new process_workflows_for_cancels if study.status is abandoned or on hold
 - changed WorkflowProcessor.reset from class method to instance method so we can call self.cancel_notify
 - change all calls to WorkflowProcessor.reset to reflect the change from class method to instance method
 - added tests/study/test_study_cancellations and tests/data/study_cancellations for testing new code
 - added some tests to tests/workflow/test_workflow_restart to make sure cancel_notify events are called during a reset
