### PR TITLE
Hidden and required fields 185

### DIFF
--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -154,8 +154,14 @@ class WorkflowService(object):
                 result = WorkflowService.evaluate_property(Task.FIELD_PROP_LABEL_EXPRESSION, field, task)
                 field.label = result
 
-            # If the field is hidden, it should not produce a value.
-            if field.has_property(Task.FIELD_PROP_HIDE_EXPRESSION):
+            # If a field is hidden and required, it must have a default value or value_expression
+            if field.has_property(Task.FIELD_PROP_HIDE_EXPRESSION) and field.has_validation(Task.FIELD_CONSTRAINT_REQUIRED):
+                if not field.has_property(Task.FIELD_PROP_VALUE_EXPRESSION) or not (hasattr(field, 'default_value')):
+                    raise ApiError(code='hidden and required field missing default',
+                                   message='Fields that are required but can be hidden must have either a default value or a value_expression')
+
+            # If the field is hidden and not required, it should not produce a value.
+            if field.has_property(Task.FIELD_PROP_HIDE_EXPRESSION) and not field.has_validation(Task.FIELD_CONSTRAINT_REQUIRED):
                 if WorkflowService.evaluate_property(Task.FIELD_PROP_HIDE_EXPRESSION, field, task):
                     continue
 

--- a/tests/data/hidden_required_field/hidden_required_field.bpmn
+++ b/tests/data/hidden_required_field/hidden_required_field.bpmn
@@ -1,0 +1,116 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1mhc2v8" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="Process_HiddenRequired" name="Hidden Reguired Field" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0zt7wv5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0zt7wv5" sourceRef="StartEvent_1" targetRef="Activity_Hello" />
+    <bpmn:userTask id="Activity_HiddenField" name="Hidden Field" camunda:formKey="HiddenFieldForm">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="name" label="Name" type="string">
+            <camunda:properties>
+              <camunda:property id="hide_expression" value="hide_yes_no" />
+            </camunda:properties>
+            <camunda:validation>
+              <camunda:constraint name="required" config="require_yes_no" />
+            </camunda:validation>
+          </camunda:formField>
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0fb4w15</bpmn:incoming>
+      <bpmn:outgoing>Flow_0c2rym0</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0cm6imh" sourceRef="Activity_Hello" targetRef="Activity_PreData" />
+    <bpmn:scriptTask id="Activity_PreData" name="Pre Data">
+      <bpmn:incoming>Flow_0cm6imh</bpmn:incoming>
+      <bpmn:outgoing>Flow_0fb4w15</bpmn:outgoing>
+      <bpmn:script>if not 'require_yes_no' in globals():
+    require_yes_no = True
+if not 'hide_yes_no' in globals():
+    hide_yes_no = True</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_0fb4w15" sourceRef="Activity_PreData" targetRef="Activity_HiddenField" />
+    <bpmn:manualTask id="Activity_GoodBye" name="Good Bye">
+      <bpmn:documentation>&lt;H1&gt;Good Bye{% if name %} {{ name }}{% endif %}&lt;/H1&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_1qkjkbh</bpmn:incoming>
+      <bpmn:outgoing>Flow_1udbzd6</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:endEvent id="Event_194gjyj">
+      <bpmn:incoming>Flow_1udbzd6</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_1udbzd6" sourceRef="Activity_GoodBye" targetRef="Event_194gjyj" />
+    <bpmn:manualTask id="Activity_Hello" name="Hello">
+      <bpmn:documentation>&lt;H1&gt;Hello&lt;/H1&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_0zt7wv5</bpmn:incoming>
+      <bpmn:outgoing>Flow_0cm6imh</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="Flow_0c2rym0" sourceRef="Activity_HiddenField" targetRef="Activity_CheckDefault" />
+    <bpmn:sequenceFlow id="Flow_1qkjkbh" sourceRef="Activity_CheckDefault" targetRef="Activity_GoodBye" />
+    <bpmn:userTask id="Activity_CheckDefault" name="Check Default" camunda:formKey="CheckDefaultForm">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="color" label="Color" type="string" defaultValue="Gray">
+            <camunda:properties>
+              <camunda:property id="hide_expression" value="True" />
+            </camunda:properties>
+            <camunda:validation>
+              <camunda:constraint name="required" config="True" />
+            </camunda:validation>
+          </camunda:formField>
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_0c2rym0</bpmn:incoming>
+      <bpmn:outgoing>Flow_1qkjkbh</bpmn:outgoing>
+    </bpmn:userTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_HiddenRequired">
+      <bpmndi:BPMNEdge id="Flow_0fb4w15_di" bpmnElement="Flow_0fb4w15">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="590" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0cm6imh_di" bpmnElement="Flow_0cm6imh">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0zt7wv5_di" bpmnElement="Flow_0zt7wv5">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0c2rym0_di" bpmnElement="Flow_0c2rym0">
+        <di:waypoint x="690" y="117" />
+        <di:waypoint x="750" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1qkjkbh_di" bpmnElement="Flow_1qkjkbh">
+        <di:waypoint x="850" y="117" />
+        <di:waypoint x="910" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1udbzd6_di" bpmnElement="Flow_1udbzd6">
+        <di:waypoint x="1010" y="117" />
+        <di:waypoint x="1072" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0a4wzou_di" bpmnElement="Activity_HiddenField">
+        <dc:Bounds x="590" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0kjyqk8_di" bpmnElement="Activity_PreData">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0v7ietz_di" bpmnElement="Activity_Hello">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_12r6tn2_di" bpmnElement="Activity_GoodBye">
+        <dc:Bounds x="910" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_194gjyj_di" bpmnElement="Event_194gjyj">
+        <dc:Bounds x="1072" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0y8y596_di" bpmnElement="Activity_CheckDefault">
+        <dc:Bounds x="750" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/workflow/test_workflow_hidden_required_field.py
+++ b/tests/workflow/test_workflow_hidden_required_field.py
@@ -1,0 +1,37 @@
+from tests.base_test import BaseTest
+import json
+
+
+class TestWorkflowHiddenRequiredField(BaseTest):
+
+    def test_require_default(self):
+        # We have a field that can be hidden and required.
+        # Validation should fail if we don't have a default value.
+        spec_model = self.load_test_spec('hidden_required_field')
+        rv = self.app.get('/v1.0/workflow-specification/%s/validate' % spec_model.id, headers=self.logged_in_headers())
+
+        json_data = json.loads(rv.get_data(as_text=True))
+        self.assertEqual(json_data[0]['code'], 'hidden and required field missing default')
+
+    def test_default_used(self):
+        # If a field is hidden and required, make sure we use the default value
+
+        workflow = self.create_workflow('hidden_required_field')
+        workflow_api = self.get_workflow_api(workflow)
+
+        first_task = workflow_api.next_task
+        self.assertEqual('Activity_Hello', first_task.name)
+        workflow_api = self.get_workflow_api(workflow)
+
+        self.complete_form(workflow_api, first_task, {})
+        workflow_api = self.get_workflow_api(workflow)
+
+        second_task = workflow_api.next_task
+        self.assertEqual('Activity_HiddenField', second_task.name)
+        self.complete_form(workflow_api, second_task, {})
+        workflow_api = self.get_workflow_api(workflow)
+
+        # The color field is hidden and required. Make sure we use the default value
+        third_task = workflow_api.next_task
+        self.assertEqual('Activity_CheckDefault', third_task.name)
+        self.assertEqual('Gray', third_task.data['color'])


### PR DESCRIPTION
We now require fields that can be hidded and required to have a default_value or value_expression.
Added a check in workflow_service.populate_form_with_random_data
Also modified the existing check for hidden fields. It now checks whether the field is required too.