### PR TITLE
We now allow value_expression to evaluate to an empty string ("") so …

### DIFF
--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -256,6 +256,8 @@ class WorkflowService(object):
             return None
 
         if field.type == "enum" and not has_lookup:
+            if isinstance(default, str) and default.strip() == '':
+                return
             default_option = next((obj for obj in field.options if obj.id == default), None)
             if not default_option:
                 raise ApiError.from_task("invalid_default", "You specified a default value that does not exist in "

--- a/tests/data/test_value_expression/test_value_expression.bpmn
+++ b/tests/data/test_value_expression/test_value_expression.bpmn
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0l37fag" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="Process_TestValueExpression" name="Test Value Expression" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1nc3qi5</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1nc3qi5" sourceRef="StartEvent_1" targetRef="Activity_Hello" />
+    <bpmn:sequenceFlow id="Flow_1t2lo17" sourceRef="Activity_Hello" targetRef="Activity_PreData" />
+    <bpmn:sequenceFlow id="Flow_1hhfj67" sourceRef="Activity_PreData" targetRef="Activity_Data" />
+    <bpmn:manualTask id="Activity_Hello" name="Hello">
+      <bpmn:documentation>&lt;H1&gt;Hello&lt;/H1&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_1nc3qi5</bpmn:incoming>
+      <bpmn:outgoing>Flow_1t2lo17</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:scriptTask id="Activity_PreData" name="Pre Data">
+      <bpmn:incoming>Flow_1t2lo17</bpmn:incoming>
+      <bpmn:outgoing>Flow_1hhfj67</bpmn:outgoing>
+      <bpmn:script>if not 'value_expression_value' in globals():
+    value_expression_value = ""</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:userTask id="Activity_Data" name="Data" camunda:formKey="DataForm">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="color" label="Select" type="enum">
+            <camunda:properties>
+              <camunda:property id="value_expression" value="value_expression_value" />
+            </camunda:properties>
+            <camunda:value id="black" name="Black" />
+            <camunda:value id="white" name="White" />
+          </camunda:formField>
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1hhfj67</bpmn:incoming>
+      <bpmn:outgoing>Flow_1skkg5a</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_1skkg5a" sourceRef="Activity_Data" targetRef="Activity_GoodBye" />
+    <bpmn:manualTask id="Activity_GoodBye" name="Good Bye">
+      <bpmn:documentation>&lt;H1&gt;Good Bye&lt;/H1&gt;</bpmn:documentation>
+      <bpmn:incoming>Flow_1skkg5a</bpmn:incoming>
+      <bpmn:outgoing>Flow_057as2q</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:endEvent id="Event_06wbkzi">
+      <bpmn:incoming>Flow_057as2q</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_057as2q" sourceRef="Activity_GoodBye" targetRef="Event_06wbkzi" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_TestValueExpression">
+      <bpmndi:BPMNEdge id="Flow_1nc3qi5_di" bpmnElement="Flow_1nc3qi5">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1t2lo17_di" bpmnElement="Flow_1t2lo17">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="431" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1hhfj67_di" bpmnElement="Flow_1hhfj67">
+        <di:waypoint x="531" y="117" />
+        <di:waypoint x="590" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1skkg5a_di" bpmnElement="Flow_1skkg5a">
+        <di:waypoint x="690" y="117" />
+        <di:waypoint x="750" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_057as2q_di" bpmnElement="Flow_057as2q">
+        <di:waypoint x="850" y="117" />
+        <di:waypoint x="912" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0hi68vh_di" bpmnElement="Activity_Hello">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1i60o9l_di" bpmnElement="Activity_Data">
+        <dc:Bounds x="590" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1b8d6dc_di" bpmnElement="Activity_GoodBye">
+        <dc:Bounds x="750" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06wbkzi_di" bpmnElement="Event_06wbkzi">
+        <dc:Bounds x="912" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_115dslj_di" bpmnElement="Activity_PreData">
+        <dc:Bounds x="431" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/workflow/test_workflow_value_expression.py
+++ b/tests/workflow/test_workflow_value_expression.py
@@ -1,0 +1,31 @@
+from tests.base_test import BaseTest
+
+
+class TestValueExpression(BaseTest):
+
+    def test_value_expression_no_default(self):
+
+        workflow = self.create_workflow('test_value_expression')
+
+        workflow_api = self.get_workflow_api(workflow)
+        first_task = workflow_api.next_task
+        self.complete_form(workflow_api, first_task, {'value_expression_value': ''})
+
+        workflow_api = self.get_workflow_api(workflow)
+        second_task = workflow_api.next_task
+        self.assertEqual('', second_task.data['value_expression_value'])
+        self.assertNotIn('color', second_task.data)
+
+    def test_value_expression_with_default(self):
+
+        workflow = self.create_workflow('test_value_expression')
+
+        workflow_api = self.get_workflow_api(workflow)
+        first_task = workflow_api.next_task
+        self.complete_form(workflow_api, first_task, {'value_expression_value': 'black'})
+
+        workflow_api = self.get_workflow_api(workflow)
+        second_task = workflow_api.next_task
+        self.assertEqual('black', second_task.data['value_expression_value'])
+        self.assertIn('color', second_task.data)
+        self.assertEqual('black', second_task.data['color']['value'])


### PR DESCRIPTION
…that we *do not* set a default value for enums in some cases.

This was causing an error because "" was not an option for the enum.

*** Dan: I only had to test for the empty string, because we test for None in the lines right above our change.