### PR TITLE
The email script was failing validation because of missing parameters…

### DIFF
--- a/crc/scripts/email.py
+++ b/crc/scripts/email.py
@@ -26,7 +26,7 @@ Example:
 email ("My Subject", "dhf8r@virginia.edu", pi.email)
 """
 
-    def do_task_validate_only(self, task, *args, **kwargs):
+    def do_task_validate_only(self, task, study_id, workflow_id, *args, **kwargs):
         self.get_subject(args)
         self.get_email_recipients(task, args)
         self.get_content(task)

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -166,6 +166,8 @@ class WorkflowService(object):
             # If we have a default_value or value_expression, try to set the default
             if field.has_property(Task.FIELD_PROP_VALUE_EXPRESSION) or (hasattr(field, 'default_value') and field.default_value):
                 form_data[field.id] = WorkflowService.get_default_value(field, task)
+                if not field.has_property(Task.FIELD_PROP_REPEAT):
+                    continue
 
             # If we are only populating required fields, and this isn't required. stop here.
             if required_only:

--- a/tests/test_email_script.py
+++ b/tests/test_email_script.py
@@ -1,8 +1,18 @@
 from tests.base_test import BaseTest
 from crc import mail
+import json
 
 
 class TestEmailScript(BaseTest):
+
+    def test_email_script_validation(self):
+        # This validates scripts.email.do_task_validate_only
+        # It also tests that we don't overwrite the default email_address with random text during validation
+        # Otherwise json would have an error about parsing the email address
+        self.load_example_data()
+        spec_model = self.load_test_spec('email_script')
+        rv = self.app.get('/v1.0/workflow-specification/%s/validate' % spec_model.id, headers=self.logged_in_headers())
+        self.assertEqual([], rv.json)
 
     def test_email_script(self):
         with mail.record_messages() as outbox:
@@ -12,6 +22,7 @@ class TestEmailScript(BaseTest):
             first_task = self.get_workflow_api(workflow).next_task
 
             workflow = self.get_workflow_api(workflow)
+            self.assertEqual('dan@sartography.com', workflow.next_task.data['email_address'])
             self.complete_form(workflow, first_task, {'email_address': 'test@example.com'})
 
             self.assertEqual(1, len(outbox))


### PR DESCRIPTION
… in scripts.email.do_task_validate_only.

I added a test in tests.test_email_script to make sure we get the default email_address.
I also found and fixed a bug in workflow_service.populate_form_with_random_data where we would overwrite default_values with random text because of a missing continue.
(We don't want to continue if we have repeating fields though.)

This covers 2 tickets; 195 and 197