### PR TITLE
UVA asked us to remove the extra whitespace in emails.

### DIFF
--- a/crc/scripts/email.py
+++ b/crc/scripts/email.py
@@ -105,7 +105,7 @@ email ("My Subject", "dhf8r@virginia.edu", pi.email)
         content = task.task_spec.documentation
         template = Template(content)
         rendered = template.render(task.data)
-        rendered_markdown = markdown.markdown(rendered).replace('\n', '<br>')
+        rendered_markdown = markdown.markdown(rendered)
         wrapped = self.get_cr_connect_wrapper(rendered_markdown)
 
         return rendered, wrapped


### PR DESCRIPTION
We removed the string replacement of '\n' -> '<br>' to solve this.
This means you can't purposely add blank lines any more.
Trade offs.

Current tests pass. 
No new test added. 