### PR TITLE
We now include field.id in the ApiError message for hidden and defaul…

### DIFF
--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -156,9 +156,10 @@ class WorkflowService(object):
 
             # If a field is hidden and required, it must have a default value or value_expression
             if field.has_property(Task.FIELD_PROP_HIDE_EXPRESSION) and field.has_validation(Task.FIELD_CONSTRAINT_REQUIRED):
-                if not field.has_property(Task.FIELD_PROP_VALUE_EXPRESSION) or not (hasattr(field, 'default_value')):
+                if not field.has_property(Task.FIELD_PROP_VALUE_EXPRESSION) and \
+                        (not (hasattr(field, 'default_value')) or field.default_value is None):
                     raise ApiError(code='hidden and required field missing default',
-                                   message='Fields that are required but can be hidden must have either a default value or a value_expression',
+                                   message=f'Field "{field.id}" is required but can be hidden. It must have either a default value or a value_expression',
                                    task_id='task.id',
                                    task_name=task.get_name())
 

--- a/tests/data/hidden_required_field_pass/hidden_required_field_pass.bpmn
+++ b/tests/data/hidden_required_field_pass/hidden_required_field_pass.bpmn
@@ -8,7 +8,7 @@
     <bpmn:userTask id="Activity_HiddenField" name="Hidden Field" camunda:formKey="HiddenFieldForm">
       <bpmn:extensionElements>
         <camunda:formData>
-          <camunda:formField id="name" label="Name" type="string">
+          <camunda:formField id="name" label="Name" type="string" defaultValue="World">
             <camunda:properties>
               <camunda:property id="hide_expression" value="hide_yes_no" />
             </camunda:properties>
@@ -33,9 +33,8 @@ if not 'hide_yes_no' in globals():
     <bpmn:sequenceFlow id="Flow_0fb4w15" sourceRef="Activity_PreData" targetRef="Activity_HiddenField" />
     <bpmn:manualTask id="Activity_GoodBye" name="Good Bye">
       <bpmn:documentation>&lt;H1&gt;Good Bye{% if name %} {{ name }}{% endif %}&lt;/H1&gt;
-&lt;div&gt;&lt;span&gt;Color is {{ color }}&lt;/span&gt;&lt;/div&gt;
 </bpmn:documentation>
-      <bpmn:incoming>Flow_1qkjkbh</bpmn:incoming>
+      <bpmn:incoming>Flow_0c2rym0</bpmn:incoming>
       <bpmn:outgoing>Flow_1udbzd6</bpmn:outgoing>
     </bpmn:manualTask>
     <bpmn:endEvent id="Event_194gjyj">
@@ -47,24 +46,7 @@ if not 'hide_yes_no' in globals():
       <bpmn:incoming>Flow_0zt7wv5</bpmn:incoming>
       <bpmn:outgoing>Flow_0cm6imh</bpmn:outgoing>
     </bpmn:manualTask>
-    <bpmn:sequenceFlow id="Flow_0c2rym0" sourceRef="Activity_HiddenField" targetRef="Activity_CheckDefault" />
-    <bpmn:sequenceFlow id="Flow_1qkjkbh" sourceRef="Activity_CheckDefault" targetRef="Activity_GoodBye" />
-    <bpmn:userTask id="Activity_CheckDefault" name="Check Default" camunda:formKey="CheckDefaultForm">
-      <bpmn:extensionElements>
-        <camunda:formData>
-          <camunda:formField id="color" label="Color" type="string" defaultValue="Gray">
-            <camunda:properties>
-              <camunda:property id="hide_expression" value="True" />
-            </camunda:properties>
-            <camunda:validation>
-              <camunda:constraint name="required" config="True" />
-            </camunda:validation>
-          </camunda:formField>
-        </camunda:formData>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0c2rym0</bpmn:incoming>
-      <bpmn:outgoing>Flow_1qkjkbh</bpmn:outgoing>
-    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0c2rym0" sourceRef="Activity_HiddenField" targetRef="Activity_GoodBye" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_HiddenRequired">
@@ -84,13 +66,9 @@ if not 'hide_yes_no' in globals():
         <di:waypoint x="690" y="117" />
         <di:waypoint x="750" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1qkjkbh_di" bpmnElement="Flow_1qkjkbh">
-        <di:waypoint x="850" y="117" />
-        <di:waypoint x="910" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1udbzd6_di" bpmnElement="Flow_1udbzd6">
-        <di:waypoint x="1010" y="117" />
-        <di:waypoint x="1072" y="117" />
+        <di:waypoint x="850" y="117" />
+        <di:waypoint x="912" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
@@ -105,13 +83,10 @@ if not 'hide_yes_no' in globals():
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_12r6tn2_di" bpmnElement="Activity_GoodBye">
-        <dc:Bounds x="910" y="77" width="100" height="80" />
+        <dc:Bounds x="750" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_194gjyj_di" bpmnElement="Event_194gjyj">
-        <dc:Bounds x="1072" y="99" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0y8y596_di" bpmnElement="Activity_CheckDefault">
-        <dc:Bounds x="750" y="77" width="100" height="80" />
+        <dc:Bounds x="912" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/tests/data/hidden_required_field_pass_expression/hidden_required_field_pass_expression.bpmn
+++ b/tests/data/hidden_required_field_pass_expression/hidden_required_field_pass_expression.bpmn
@@ -10,10 +10,11 @@
         <camunda:formData>
           <camunda:formField id="name" label="Name" type="string">
             <camunda:properties>
-              <camunda:property id="hide_expression" value="hide_yes_no" />
+              <camunda:property id="hide_expression" value="True" />
+              <camunda:property id="value_expression" value="value_expression_value" />
             </camunda:properties>
             <camunda:validation>
-              <camunda:constraint name="required" config="require_yes_no" />
+              <camunda:constraint name="required" config="True" />
             </camunda:validation>
           </camunda:formField>
         </camunda:formData>
@@ -28,14 +29,15 @@
       <bpmn:script>if not 'require_yes_no' in globals():
     require_yes_no = True
 if not 'hide_yes_no' in globals():
-    hide_yes_no = True</bpmn:script>
+    hide_yes_no = True
+if not 'value_expression_value' in globals():
+    value_expression_value = 'World'</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_0fb4w15" sourceRef="Activity_PreData" targetRef="Activity_HiddenField" />
     <bpmn:manualTask id="Activity_GoodBye" name="Good Bye">
       <bpmn:documentation>&lt;H1&gt;Good Bye{% if name %} {{ name }}{% endif %}&lt;/H1&gt;
-&lt;div&gt;&lt;span&gt;Color is {{ color }}&lt;/span&gt;&lt;/div&gt;
 </bpmn:documentation>
-      <bpmn:incoming>Flow_1qkjkbh</bpmn:incoming>
+      <bpmn:incoming>Flow_0c2rym0</bpmn:incoming>
       <bpmn:outgoing>Flow_1udbzd6</bpmn:outgoing>
     </bpmn:manualTask>
     <bpmn:endEvent id="Event_194gjyj">
@@ -47,24 +49,7 @@ if not 'hide_yes_no' in globals():
       <bpmn:incoming>Flow_0zt7wv5</bpmn:incoming>
       <bpmn:outgoing>Flow_0cm6imh</bpmn:outgoing>
     </bpmn:manualTask>
-    <bpmn:sequenceFlow id="Flow_0c2rym0" sourceRef="Activity_HiddenField" targetRef="Activity_CheckDefault" />
-    <bpmn:sequenceFlow id="Flow_1qkjkbh" sourceRef="Activity_CheckDefault" targetRef="Activity_GoodBye" />
-    <bpmn:userTask id="Activity_CheckDefault" name="Check Default" camunda:formKey="CheckDefaultForm">
-      <bpmn:extensionElements>
-        <camunda:formData>
-          <camunda:formField id="color" label="Color" type="string" defaultValue="Gray">
-            <camunda:properties>
-              <camunda:property id="hide_expression" value="True" />
-            </camunda:properties>
-            <camunda:validation>
-              <camunda:constraint name="required" config="True" />
-            </camunda:validation>
-          </camunda:formField>
-        </camunda:formData>
-      </bpmn:extensionElements>
-      <bpmn:incoming>Flow_0c2rym0</bpmn:incoming>
-      <bpmn:outgoing>Flow_1qkjkbh</bpmn:outgoing>
-    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_0c2rym0" sourceRef="Activity_HiddenField" targetRef="Activity_GoodBye" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_HiddenRequired">
@@ -84,13 +69,9 @@ if not 'hide_yes_no' in globals():
         <di:waypoint x="690" y="117" />
         <di:waypoint x="750" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1qkjkbh_di" bpmnElement="Flow_1qkjkbh">
-        <di:waypoint x="850" y="117" />
-        <di:waypoint x="910" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1udbzd6_di" bpmnElement="Flow_1udbzd6">
-        <di:waypoint x="1010" y="117" />
-        <di:waypoint x="1072" y="117" />
+        <di:waypoint x="850" y="117" />
+        <di:waypoint x="912" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
@@ -105,13 +86,10 @@ if not 'hide_yes_no' in globals():
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_12r6tn2_di" bpmnElement="Activity_GoodBye">
-        <dc:Bounds x="910" y="77" width="100" height="80" />
+        <dc:Bounds x="750" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_194gjyj_di" bpmnElement="Event_194gjyj">
-        <dc:Bounds x="1072" y="99" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0y8y596_di" bpmnElement="Activity_CheckDefault">
-        <dc:Bounds x="750" y="77" width="100" height="80" />
+        <dc:Bounds x="912" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/tests/workflow/test_workflow_hidden_required_field.py
+++ b/tests/workflow/test_workflow_hidden_required_field.py
@@ -14,6 +14,17 @@ class TestWorkflowHiddenRequiredField(BaseTest):
         self.assertEqual(json_data[0]['code'], 'hidden and required field missing default')
         self.assertIn('task_id', json_data[0])
         self.assertIn('task_name', json_data[0])
+        self.assertIn('Field "name" is required but can be hidden', json_data[0]['message'])
+
+    def test_require_default_pass(self):
+        spec_model = self.load_test_spec('hidden_required_field_pass')
+        rv = self.app.get('/v1.0/workflow-specification/%s/validate' % spec_model.id, headers=self.logged_in_headers())
+        self.assertEqual(0, len(rv.json))
+
+    def test_require_default_pass_expression(self):
+        spec_model = self.load_test_spec('hidden_required_field_pass_expression')
+        rv = self.app.get('/v1.0/workflow-specification/%s/validate' % spec_model.id, headers=self.logged_in_headers())
+        self.assertEqual(0, len(rv.json))
 
     def test_default_used(self):
         # If a field is hidden and required, make sure we use the default value


### PR DESCRIPTION
…t validation. (The field must have a default value or value expression)

While working on this ticket I found a logic error in the if statement in workflow_service. 
I expected both default_value and value_expression. 
And, it turns out the default_value is always there, it's just null if we don't set it.

Modified the existing test for hidden and required, and added tests to make sure my passing logic is now correct.

The important parts here are the changes to workflow_service.