### PR TITLE
Sometimes a workflow can be completely broken and unload-able. For ins…

### DIFF
--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -120,7 +120,7 @@ def restart_workflow(workflow_id, clear_data=False):
     """Restart a workflow with the latest spec.
        Clear data allows user to restart the workflow without previous data."""
     workflow_model: WorkflowModel = session.query(WorkflowModel).filter_by(id=workflow_id).first()
-    WorkflowProcessor(workflow_model).reset(workflow_model, clear_data=clear_data)
+    WorkflowProcessor.reset(workflow_model, clear_data=clear_data)
     return get_workflow(workflow_model.id)
 
 

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -731,5 +731,4 @@ class WorkflowService(object):
         workflows = db.session.query(WorkflowModel).filter_by(study_id=study_id).all()
         for workflow in workflows:
             if workflow.status == WorkflowStatus.user_input_required or workflow.status == WorkflowStatus.waiting:
-                processor = WorkflowProcessor(workflow)
-                processor.reset(workflow)
+                WorkflowProcessor.reset(workflow, clear_data=False)

--- a/tests/test_lookup_service.py
+++ b/tests/test_lookup_service.py
@@ -54,8 +54,7 @@ class TestLookupService(BaseTest):
 
         # restart the workflow, so it can pick up the changes.
 
-        processor = WorkflowProcessor(workflow)
-        processor.reset(workflow)
+        processor = WorkflowProcessor.reset(workflow)
         workflow = processor.workflow_model
 
         LookupService.lookup(workflow, "Task_Enum_Lookup", "sponsor", "sam", limit=10)
@@ -92,8 +91,7 @@ class TestLookupService(BaseTest):
         results = LookupService.lookup(workflow, task.task_spec.name, "selectedItem", "", value="apples", limit=10)
         self.assertEqual(0, len(results), "We shouldn't find our fruits mixed in with our animals.")
 
-
-        processor.reset(workflow, clear_data=True)
+        processor = WorkflowProcessor.reset(workflow, clear_data=True)
         processor.do_engine_steps()
         task = processor.get_ready_user_tasks()[0]
         task.data = {"type": "fruit"}

--- a/tests/workflow/test_workflow_processor.py
+++ b/tests/workflow/test_workflow_processor.py
@@ -279,7 +279,7 @@ class TestWorkflowProcessor(BaseTest):
         self.assertFalse(processor2.is_latest_spec) # Still at version 1.
 
         # Do a hard reset, which should bring us back to the beginning, but retain the data.
-        processor2.reset(processor2.workflow_model)
+        processor2 = WorkflowProcessor.reset(processor2.workflow_model)
         processor3 = WorkflowProcessor(processor.workflow_model)
         processor3.do_engine_steps()
         self.assertEqual("Step 1", processor3.next_task().task_spec.description)


### PR DESCRIPTION
…tance, it starts off with a engine step / script task that will not execute.  So the failure happens the second it is processed.  When calling reset on a workflow, we should catch the failure, and reset the workflow, so we aren't trapped in an unrecoverable state.

 To do so, I changed the WorkflowProcessor's reset method to be static, it will try to instantiate the current workflow and execute a cancel_notify event, but if that fails, it will continue and always return a new workflow processor using the latest spec.