### PR TITLE
The `do_task_validate_only` method in the `get_study_associates` scri…

### DIFF
--- a/crc/scripts/get_study_associates.py
+++ b/crc/scripts/get_study_associates.py
@@ -19,8 +19,11 @@ example : get_study_associates() => [{'uid':'sbp3ey','role':'Unicorn Herder', 's
 """
 
     def do_task_validate_only(self, task, study_id, workflow_id, *args, **kwargs):
-        return True
-
+        study_associates = [
+            {'uid': 'dhf8r', 'role': 'Chief Bee Keeper', 'send_email': True, 'access': True},
+            {'uid': 'lb3dp', 'role': 'Chief Cat Herder', 'send_email': True, 'access': True}
+        ]
+        return study_associates
 
     def do_task(self, task, study_id, workflow_id, *args, **kwargs):
 

--- a/tests/data/study_sponsors_associate/study_sponsors_associate.bpmn
+++ b/tests/data/study_sponsors_associate/study_sponsors_associate.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0kmksnn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_0kmksnn" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.5.0">
   <bpmn:process id="Process_0exnnpv" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1nfe5m9</bpmn:outgoing>
@@ -30,7 +30,10 @@ out4 = get_study_associate('lb3dp')</bpmn:script>
     <bpmn:scriptTask id="Activity_0run091" name="setval - 2">
       <bpmn:incoming>Flow_14n3ixy</bpmn:incoming>
       <bpmn:outgoing>Flow_1vlh6s0</bpmn:outgoing>
-      <bpmn:script>update_study_associates([{'uid':'lb3dp','role':'SuperGal','send_email':False,'access':True}])</bpmn:script>
+      <bpmn:script>uids = []
+for assoc in out:
+   uids.append(assoc['uid'])
+update_study_associates([{'uid':'lb3dp','role':'SuperGal','send_email':False,'access':True}])</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_1vlh6s0" sourceRef="Activity_0run091" targetRef="Activity_0d8iftx" />
     <bpmn:scriptTask id="Activity_14td33q" name="getval">

--- a/tests/study/test_study_associate_script.py
+++ b/tests/study/test_study_associate_script.py
@@ -1,10 +1,10 @@
+from tests.base_test import BaseTest
 import json
 from unittest.mock import patch
 import flask
 
 from crc.api.common import ApiError
 from crc.services.user_service import UserService
-from tests.base_test import BaseTest
 
 from crc import session, app
 from crc.models.study import StudyModel


### PR DESCRIPTION
…pt now returns a mocked list of associates.

It used to return `True`, and this caused shield validation to fail when looping over the results of `get_study_associates`.
(You can't loop over a boolean)

Added a for loop in `study_sponsors_associate.bpmn` to test for this.
Moved `BaseTest` import to the top of `test_study_associate_script` because debug was failing.