### PR TITLE
Infinite validations 262

### DIFF
--- a/crc/scripts/study_info.py
+++ b/crc/scripts/study_info.py
@@ -80,7 +80,12 @@ class StudyInfo(Script):
                     'display': 'Optional',
                     'unique': 'Yes',
                     'user_id': 'asd3v',
-                    'error': 'Unable to locate a user with id asd3v in LDAP'}
+                    'error': 'Unable to locate a user with id asd3v in LDAP'},
+                'DEPT_CH': {
+                    'label': 'Department Chair',
+                    'display': 'Always',
+                    'unique': 'Yes',
+                    'user_id': 'lb3dp'}
             },
             "documents": {
                 'AD_CoCApp': {'category1': 'Ancillary Document', 'category2': 'CoC Application', 'category3': '',

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -97,7 +97,7 @@ class WorkflowService(object):
 
         count = 0
         while not processor.bpmn_workflow.is_completed():
-            if count < 1000:
+            if count < 100:  # check for infinite loop
                 try:
                     processor.bpmn_workflow.get_deep_nav_list()  # Assure no errors with navigation.
                     processor.bpmn_workflow.do_engine_steps()
@@ -124,8 +124,9 @@ class WorkflowService(object):
                     WorkflowService.delete_test_data()
                     raise ApiError.from_workflow_exception("workflow_validation_exception", str(we), we)
             else:
-                raise ApiError.from_workflow_exception(code='validation_loop',
-                                                       message=f'There appears to be an infinite loop in the validation. spec_id: {spec_id}')
+                raise ApiError.from_task(code='validation_loop',
+                                         message=f'There appears to be an infinite loop in the validation. Task is {task.task_spec.description}',
+                                         task=task)
 
         WorkflowService.delete_test_data()
         WorkflowService._process_documentation(processor.bpmn_workflow.last_task.parent.parent)

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -95,31 +95,37 @@ class WorkflowService(object):
             WorkflowService.delete_test_data()
             raise ApiError.from_workflow_exception("workflow_validation_exception", str(we), we)
 
+        count = 0
         while not processor.bpmn_workflow.is_completed():
-            try:
-                processor.bpmn_workflow.get_deep_nav_list()  # Assure no errors with navigation.
-                processor.bpmn_workflow.do_engine_steps()
-                tasks = processor.bpmn_workflow.get_tasks(SpiffTask.READY)
-                for task in tasks:
-                    if task.task_spec.lane is not None and task.task_spec.lane not in task.data:
-                        raise ApiError.from_task("invalid_role",
-                                       f"This task is in a lane called '{task.task_spec.lane}', The "
-                                       f" current task data must have information mapping this role to "
-                                       f" a unique user id.", task)
-                    task_api = WorkflowService.spiff_task_to_api_task(
-                        task,
-                        add_docs_and_forms=True)  # Assure we try to process the documentation, and raise those errors.
-                    # make sure forms have a form key
-                    if hasattr(task_api, 'form') and task_api.form is not None and task_api.form.key == '':
-                        raise ApiError(code='missing_form_key',
-                                       message='Forms must include a Form Key.',
-                                       task_id=task.id,
-                                       task_name=task.get_name())
-                    WorkflowService.populate_form_with_random_data(task, task_api, required_only)
-                    processor.complete_task(task)
-            except WorkflowException as we:
-                WorkflowService.delete_test_data()
-                raise ApiError.from_workflow_exception("workflow_validation_exception", str(we), we)
+            if count < 1000:
+                try:
+                    processor.bpmn_workflow.get_deep_nav_list()  # Assure no errors with navigation.
+                    processor.bpmn_workflow.do_engine_steps()
+                    tasks = processor.bpmn_workflow.get_tasks(SpiffTask.READY)
+                    for task in tasks:
+                        if task.task_spec.lane is not None and task.task_spec.lane not in task.data:
+                            raise ApiError.from_task("invalid_role",
+                                           f"This task is in a lane called '{task.task_spec.lane}', The "
+                                           f" current task data must have information mapping this role to "
+                                           f" a unique user id.", task)
+                        task_api = WorkflowService.spiff_task_to_api_task(
+                            task,
+                            add_docs_and_forms=True)  # Assure we try to process the documentation, and raise those errors.
+                        # make sure forms have a form key
+                        if hasattr(task_api, 'form') and task_api.form is not None and task_api.form.key == '':
+                            raise ApiError(code='missing_form_key',
+                                           message='Forms must include a Form Key.',
+                                           task_id=task.id,
+                                           task_name=task.get_name())
+                        WorkflowService.populate_form_with_random_data(task, task_api, required_only)
+                        processor.complete_task(task)
+                    count += 1
+                except WorkflowException as we:
+                    WorkflowService.delete_test_data()
+                    raise ApiError.from_workflow_exception("workflow_validation_exception", str(we), we)
+            else:
+                raise ApiError.from_workflow_exception(code='validation_loop',
+                                                       message=f'There appears to be an infinite loop in the validation. spec_id: {spec_id}')
 
         WorkflowService.delete_test_data()
         WorkflowService._process_documentation(processor.bpmn_workflow.last_task.parent.parent)

--- a/tests/data/infinite_loop/infinite_loop.bpmn
+++ b/tests/data/infinite_loop/infinite_loop.bpmn
@@ -1,0 +1,97 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" id="Definitions_81799d0" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.5.0">
+  <bpmn:process id="Process_InfiniteLoop" name="Infinite Loop" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0ldlhrt</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0ldlhrt" sourceRef="StartEvent_1" targetRef="Activity_StudyInfo" />
+    <bpmn:scriptTask id="Activity_StudyInfo" name="Get Study Info">
+      <bpmn:incoming>Flow_0ldlhrt</bpmn:incoming>
+      <bpmn:incoming>Flow_05mrx8v</bpmn:incoming>
+      <bpmn:outgoing>Flow_0pddur1</bpmn:outgoing>
+      <bpmn:script>investigators = study_info('investigators')</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_0pddur1" sourceRef="Activity_StudyInfo" targetRef="Activity_DisplayInvestigators" />
+    <bpmn:manualTask id="Activity_DisplayInvestigators" name="Display Investigators">
+      <bpmn:documentation>Investigators: {{ investigators }}</bpmn:documentation>
+      <bpmn:incoming>Flow_0pddur1</bpmn:incoming>
+      <bpmn:outgoing>Flow_03m3cuy</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:exclusiveGateway id="Gateway_0n9lzir" name="Test DEPT_CH" default="Flow_05mrx8v">
+      <bpmn:incoming>Flow_03m3cuy</bpmn:incoming>
+      <bpmn:outgoing>Flow_05mrx8v</bpmn:outgoing>
+      <bpmn:outgoing>Flow_1212fe2</bpmn:outgoing>
+    </bpmn:exclusiveGateway>
+    <bpmn:sequenceFlow id="Flow_03m3cuy" sourceRef="Activity_DisplayInvestigators" targetRef="Gateway_0n9lzir" />
+    <bpmn:sequenceFlow id="Flow_05mrx8v" name="not has DEPT_CH" sourceRef="Gateway_0n9lzir" targetRef="Activity_StudyInfo" />
+    <bpmn:sequenceFlow id="Flow_1212fe2" name="Has DEPT_CH" sourceRef="Gateway_0n9lzir" targetRef="Activity_GoodBye">
+      <bpmn:conditionExpression xsi:type="bpmn:tFormalExpression">hasattr(investigators, 'DEPT_CH')</bpmn:conditionExpression>
+    </bpmn:sequenceFlow>
+    <bpmn:endEvent id="Event_0azm9il">
+      <bpmn:incoming>Flow_14jn215</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_14jn215" sourceRef="Activity_GoodBye" targetRef="Event_0azm9il" />
+    <bpmn:manualTask id="Activity_GoodBye" name="Good Bye">
+      <bpmn:documentation># Thank You</bpmn:documentation>
+      <bpmn:incoming>Flow_1212fe2</bpmn:incoming>
+      <bpmn:outgoing>Flow_14jn215</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_InfiniteLoop">
+      <bpmndi:BPMNEdge id="Flow_14jn215_di" bpmnElement="Flow_14jn215">
+        <di:waypoint x="810" y="177" />
+        <di:waypoint x="882" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1212fe2_di" bpmnElement="Flow_1212fe2">
+        <di:waypoint x="645" y="177" />
+        <di:waypoint x="710" y="177" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="645" y="159" width="74" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_05mrx8v_di" bpmnElement="Flow_05mrx8v">
+        <di:waypoint x="620" y="152" />
+        <di:waypoint x="620" y="80" />
+        <di:waypoint x="320" y="80" />
+        <di:waypoint x="320" y="137" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="447" y="62" width="52" height="27" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_03m3cuy_di" bpmnElement="Flow_03m3cuy">
+        <di:waypoint x="530" y="177" />
+        <di:waypoint x="595" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0pddur1_di" bpmnElement="Flow_0pddur1">
+        <di:waypoint x="370" y="177" />
+        <di:waypoint x="430" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ldlhrt_di" bpmnElement="Flow_0ldlhrt">
+        <di:waypoint x="215" y="177" />
+        <di:waypoint x="270" y="177" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1ueb1ky_di" bpmnElement="Activity_StudyInfo">
+        <dc:Bounds x="270" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1y5mgz2_di" bpmnElement="Activity_DisplayInvestigators">
+        <dc:Bounds x="430" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Gateway_0n9lzir_di" bpmnElement="Gateway_0n9lzir" isMarkerVisible="true">
+        <dc:Bounds x="595" y="152" width="50" height="50" />
+        <bpmndi:BPMNLabel>
+          <dc:Bounds x="584" y="209" width="75" height="14" />
+        </bpmndi:BPMNLabel>
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0azm9il_di" bpmnElement="Event_0azm9il">
+        <dc:Bounds x="882" y="159" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0wbzf51_di" bpmnElement="Activity_GoodBye">
+        <dc:Bounds x="710" y="137" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/workflow/test_workflow_infinite_loop.py
+++ b/tests/workflow/test_workflow_infinite_loop.py
@@ -1,0 +1,13 @@
+from tests.base_test import BaseTest
+from crc import app
+import json
+
+
+class TestWorkflowInfiniteLoop(BaseTest):
+
+    def test_workflow_infinite_loop(self):
+        self.load_example_data()
+        spec_model = self.load_test_spec('infinite_loop')
+        rv = self.app.get('/v1.0/workflow-specification/%s/validate' % spec_model.id, headers=self.logged_in_headers())
+        json_data = json.loads(rv.get_data(as_text=True))
+        self.assertIn('There appears to be an infinite loop', json_data[0]['message'])


### PR DESCRIPTION
Fix for infinite loops in validation.
Added a counter to workflow_service.test_spec
Added `DEPT_CH` to the mocked data for study_info script. This is where the bug revealed itself.

Test workflow has an infinite loop.
Test validates workflow and looks for error message.