### PR TITLE
Delete uploaded file script #283

### DIFF
--- a/crc/models/protocol_builder.py
+++ b/crc/models/protocol_builder.py
@@ -41,13 +41,12 @@ class ProtocolBuilderStatus(enum.Enum):
 class ProtocolBuilderStudy(object):
     def __init__(
             self, STUDYID: int, HSRNUMBER: str, TITLE: str, NETBADGEID: str,
-            Q_COMPLETE: bool, DATE_MODIFIED: str
+            DATE_MODIFIED: str
     ):
         self.STUDYID = STUDYID
         self.HSRNUMBER = HSRNUMBER
         self.TITLE = TITLE
         self.NETBADGEID = NETBADGEID
-        self.Q_COMPLETE = Q_COMPLETE
         self.DATE_MODIFIED = DATE_MODIFIED
 
 
@@ -56,7 +55,7 @@ class ProtocolBuilderStudySchema(ma.Schema):
         model = ProtocolBuilderStudy
         unknown = INCLUDE
         fields = ["STUDYID", "HSRNUMBER", "TITLE", "NETBADGEID",
-                  "Q_COMPLETE", "DATE_MODIFIED"]
+                  "DATE_MODIFIED"]
 
     @post_load
     def make_pbs(self, data, **kwargs):

--- a/crc/scripts/delete_irb_document.py
+++ b/crc/scripts/delete_irb_document.py
@@ -7,20 +7,8 @@ from crc.services.file_service import FileService
 
 class DeleteIRBDocument(Script):
 
-    def get_description(self):
-        return """Delete an IRB document from a workflow"""
-
-    def do_task_validate_only(self, task, study_id, workflow_id, *args, **kwargs):
-        irb_document = kwargs['irb_document']
-        result = session.query(FileModel).filter(
-            FileModel.workflow_id == workflow_id, FileModel.irb_doc_code == irb_document).all()
-        if result:
-            return True
-        return False
-
-    def do_task(self, task, study_id, workflow_id, *args, **kwargs):
-
-        irb_doc_code = kwargs['irb_document']
+    @staticmethod
+    def process_document_deletion(irb_doc_code, workflow_id, task):
         if FileService.is_allowed_document(irb_doc_code):
             result = session.query(FileModel).filter(
                 FileModel.workflow_id == workflow_id, FileModel.irb_doc_code == irb_doc_code).all()
@@ -35,3 +23,23 @@ class DeleteIRBDocument(Script):
             raise ApiError.from_task(code='invalid_irb_document',
                                      message=f'{irb_doc_code} is not a valid IRB document code',
                                      task=task)
+
+    def get_description(self):
+        return """Delete an IRB document from a workflow"""
+
+    def do_task_validate_only(self, task, study_id, workflow_id, *args, **kwargs):
+        irb_document = kwargs['irb_document']
+        result = session.query(FileModel).filter(
+            FileModel.workflow_id == workflow_id, FileModel.irb_doc_code == irb_document).all()
+        if result:
+            return True
+        return False
+
+    def do_task(self, task, study_id, workflow_id, *args, **kwargs):
+
+        irb_doc_code = kwargs['irb_document']
+        if isinstance(irb_doc_code, str):
+            self.process_document_deletion(irb_doc_code, workflow_id, task)
+        elif isinstance(irb_doc_code, list):
+            for doc_code in irb_doc_code:
+                self.process_document_deletion(doc_code, workflow_id, task)

--- a/crc/scripts/delete_irb_document.py
+++ b/crc/scripts/delete_irb_document.py
@@ -1,4 +1,5 @@
 from crc import session
+from crc.api.common import ApiError
 from crc.models.file import FileModel
 from crc.scripts.script import Script
 from crc.services.file_service import FileService
@@ -10,11 +11,27 @@ class DeleteIRBDocument(Script):
         return """Delete an IRB document from a workflow"""
 
     def do_task_validate_only(self, task, study_id, workflow_id, *args, **kwargs):
-        pass
+        irb_document = kwargs['irb_document']
+        result = session.query(FileModel).filter(
+            FileModel.workflow_id == workflow_id, FileModel.irb_doc_code == irb_document).all()
+        if result:
+            return True
+        return False
 
     def do_task(self, task, study_id, workflow_id, *args, **kwargs):
 
-        irb_document = kwargs['irb_document']
-        result = session.query(FileModel).filter(FileModel.workflow_id==workflow_id, FileModel.irb_doc_code==irb_document).all()
-        for file in result:
-            FileService.delete_file(file.id)
+        irb_doc_code = kwargs['irb_document']
+        if FileService.is_allowed_document(irb_doc_code):
+            result = session.query(FileModel).filter(
+                FileModel.workflow_id == workflow_id, FileModel.irb_doc_code == irb_doc_code).all()
+            if isinstance(result, list) and len(result) > 0 and isinstance(result[0], FileModel):
+                for file in result:
+                    FileService.delete_file(file.id)
+            else:
+                raise ApiError.from_task(code='no_document_found',
+                                         message=f'No document of type {irb_doc_code} was found for this workflow.',
+                                         task=task)
+        else:
+            raise ApiError.from_task(code='invalid_irb_document',
+                                     message=f'{irb_doc_code} is not a valid IRB document code',
+                                     task=task)

--- a/crc/scripts/delete_irb_document.py
+++ b/crc/scripts/delete_irb_document.py
@@ -1,0 +1,20 @@
+from crc import session
+from crc.models.file import FileModel
+from crc.scripts.script import Script
+from crc.services.file_service import FileService
+
+
+class DeleteIRBDocument(Script):
+
+    def get_description(self):
+        return """Delete an IRB document from a workflow"""
+
+    def do_task_validate_only(self, task, study_id, workflow_id, *args, **kwargs):
+        pass
+
+    def do_task(self, task, study_id, workflow_id, *args, **kwargs):
+
+        irb_document = kwargs['irb_document']
+        result = session.query(FileModel).filter(FileModel.workflow_id==workflow_id, FileModel.irb_doc_code==irb_document).all()
+        for file in result:
+            FileService.delete_file(file.id)

--- a/tests/data/add_delete_irb_document/add_delete_irb_document.bpmn
+++ b/tests/data/add_delete_irb_document/add_delete_irb_document.bpmn
@@ -5,10 +5,9 @@
       <bpmn:outgoing>Flow_1j6i6nv</bpmn:outgoing>
     </bpmn:startEvent>
     <bpmn:sequenceFlow id="Flow_1j6i6nv" sourceRef="StartEvent_1" targetRef="Activity_WhichIRBDocument" />
-    <bpmn:sequenceFlow id="Flow_0oyc3ye" sourceRef="Activity_WhichIRBDocument" targetRef="Activity_CheckFileUploaded" />
-    <bpmn:sequenceFlow id="Flow_1rexoi9" sourceRef="Activity_DeleteIRBDocument" targetRef="Activity_CheckFileDeleted" />
+    <bpmn:sequenceFlow id="Flow_1rexoi9" sourceRef="Activity_DeleteIRBDocument" targetRef="Event_06rfn6m" />
     <bpmn:endEvent id="Event_06rfn6m">
-      <bpmn:incoming>Flow_0ry4bnx</bpmn:incoming>
+      <bpmn:incoming>Flow_1rexoi9</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:userTask id="Activity_WhichIRBDocument" name="Which IRB Document" camunda:formKey="UploadIRBDoc">
       <bpmn:extensionElements>
@@ -17,71 +16,24 @@
         </camunda:formData>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_1j6i6nv</bpmn:incoming>
-      <bpmn:outgoing>Flow_0oyc3ye</bpmn:outgoing>
+      <bpmn:outgoing>SequenceFlow_1mmief6</bpmn:outgoing>
     </bpmn:userTask>
-    <bpmn:scriptTask id="Activity_CheckFileUploaded" name="Check File Uploaded">
-      <bpmn:incoming>Flow_0oyc3ye</bpmn:incoming>
-      <bpmn:outgoing>Flow_1gpekhi</bpmn:outgoing>
-      <bpmn:script>uploaded = is_file_uploaded(irb_document)</bpmn:script>
-    </bpmn:scriptTask>
-    <bpmn:sequenceFlow id="Flow_1gpekhi" sourceRef="Activity_CheckFileUploaded" targetRef="Activity_DisplayFileUploaded" />
-    <bpmn:manualTask id="Activity_DisplayFileUploaded" name="Display File Uploaded">
-      <bpmn:documentation># Is file uploaded
-uploaded:  {{uploaded}}</bpmn:documentation>
-      <bpmn:incoming>Flow_1gpekhi</bpmn:incoming>
-      <bpmn:outgoing>Flow_0qyam4h</bpmn:outgoing>
-    </bpmn:manualTask>
     <bpmn:scriptTask id="Activity_DeleteIRBDocument" name="Delete IRB Document">
-      <bpmn:incoming>Flow_0qyam4h</bpmn:incoming>
+      <bpmn:incoming>SequenceFlow_1mmief6</bpmn:incoming>
       <bpmn:outgoing>Flow_1rexoi9</bpmn:outgoing>
       <bpmn:script>delete_irb_document(irb_document=irb_document)</bpmn:script>
     </bpmn:scriptTask>
-    <bpmn:scriptTask id="Activity_CheckFileDeleted" name="Check File Deleted">
-      <bpmn:incoming>Flow_1rexoi9</bpmn:incoming>
-      <bpmn:outgoing>Flow_06hfqyd</bpmn:outgoing>
-      <bpmn:script>deleted = not is_file_uploaded(irb_document)</bpmn:script>
-    </bpmn:scriptTask>
-    <bpmn:sequenceFlow id="Flow_0qyam4h" sourceRef="Activity_DisplayFileUploaded" targetRef="Activity_DeleteIRBDocument" />
-    <bpmn:sequenceFlow id="Flow_06hfqyd" sourceRef="Activity_CheckFileDeleted" targetRef="Activity_DisplayFileDeleted" />
-    <bpmn:sequenceFlow id="Flow_0ry4bnx" sourceRef="Activity_DisplayFileDeleted" targetRef="Event_06rfn6m" />
-    <bpmn:manualTask id="Activity_DisplayFileDeleted" name="Display File Deleted">
-      <bpmn:documentation># Is file deleted
-deleted:  {{deleted}}</bpmn:documentation>
-      <bpmn:incoming>Flow_06hfqyd</bpmn:incoming>
-      <bpmn:outgoing>Flow_0ry4bnx</bpmn:outgoing>
-    </bpmn:manualTask>
+    <bpmn:sequenceFlow id="SequenceFlow_1mmief6" sourceRef="Activity_WhichIRBDocument" targetRef="Activity_DeleteIRBDocument" />
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_44b3aca">
-      <bpmndi:BPMNEdge id="Flow_0oyc3ye_di" bpmnElement="Flow_0oyc3ye">
-        <di:waypoint x="360" y="117" />
-        <di:waypoint x="430" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1j6i6nv_di" bpmnElement="Flow_1j6i6nv">
         <di:waypoint x="215" y="117" />
         <di:waypoint x="260" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1gpekhi_di" bpmnElement="Flow_1gpekhi">
-        <di:waypoint x="530" y="117" />
-        <di:waypoint x="590" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0qyam4h_di" bpmnElement="Flow_0qyam4h">
-        <di:waypoint x="640" y="157" />
-        <di:waypoint x="640" y="220" />
-        <di:waypoint x="310" y="220" />
-        <di:waypoint x="310" y="280" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1rexoi9_di" bpmnElement="Flow_1rexoi9">
-        <di:waypoint x="360" y="320" />
-        <di:waypoint x="430" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_06hfqyd_di" bpmnElement="Flow_06hfqyd">
-        <di:waypoint x="530" y="320" />
-        <di:waypoint x="590" y="320" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_0ry4bnx_di" bpmnElement="Flow_0ry4bnx">
-        <di:waypoint x="690" y="320" />
-        <di:waypoint x="742" y="320" />
+        <di:waypoint x="500" y="117" />
+        <di:waypoint x="562" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
@@ -89,24 +41,16 @@ deleted:  {{deleted}}</bpmn:documentation>
       <bpmndi:BPMNShape id="Activity_176crcy_di" bpmnElement="Activity_WhichIRBDocument">
         <dc:Bounds x="260" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0015703_di" bpmnElement="Activity_CheckFileUploaded">
-        <dc:Bounds x="430" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_1kmb6qu_di" bpmnElement="Activity_CheckFileDeleted">
-        <dc:Bounds x="430" y="280" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0om2kg5_di" bpmnElement="Activity_DeleteIRBDocument">
-        <dc:Bounds x="260" y="280" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_11nq3xj_di" bpmnElement="Activity_DisplayFileUploaded">
-        <dc:Bounds x="590" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0cbkkzl_di" bpmnElement="Activity_DisplayFileDeleted">
-        <dc:Bounds x="590" y="280" width="100" height="80" />
+        <dc:Bounds x="400" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_06rfn6m_di" bpmnElement="Event_06rfn6m">
-        <dc:Bounds x="742" y="302" width="36" height="36" />
+        <dc:Bounds x="562" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
+      <bpmndi:BPMNEdge id="SequenceFlow_1mmief6_di" bpmnElement="SequenceFlow_1mmief6">
+        <di:waypoint x="360" y="117" />
+        <di:waypoint x="400" y="117" />
+      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/tests/data/add_delete_irb_document/add_delete_irb_document.bpmn
+++ b/tests/data/add_delete_irb_document/add_delete_irb_document.bpmn
@@ -1,0 +1,112 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_3d948db" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.5.0">
+  <bpmn:process id="Process_44b3aca" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1j6i6nv</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1j6i6nv" sourceRef="StartEvent_1" targetRef="Activity_WhichIRBDocument" />
+    <bpmn:sequenceFlow id="Flow_0oyc3ye" sourceRef="Activity_WhichIRBDocument" targetRef="Activity_CheckFileUploaded" />
+    <bpmn:sequenceFlow id="Flow_1rexoi9" sourceRef="Activity_DeleteIRBDocument" targetRef="Activity_CheckFileDeleted" />
+    <bpmn:endEvent id="Event_06rfn6m">
+      <bpmn:incoming>Flow_0ry4bnx</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:userTask id="Activity_WhichIRBDocument" name="Which IRB Document" camunda:formKey="UploadIRBDoc">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="irb_document" label="IRB Document" type="string" defaultValue="Study_Protocol_Document" />
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1j6i6nv</bpmn:incoming>
+      <bpmn:outgoing>Flow_0oyc3ye</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:scriptTask id="Activity_CheckFileUploaded" name="Check File Uploaded">
+      <bpmn:incoming>Flow_0oyc3ye</bpmn:incoming>
+      <bpmn:outgoing>Flow_1gpekhi</bpmn:outgoing>
+      <bpmn:script>uploaded = is_file_uploaded(irb_document)</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_1gpekhi" sourceRef="Activity_CheckFileUploaded" targetRef="Activity_DisplayFileUploaded" />
+    <bpmn:manualTask id="Activity_DisplayFileUploaded" name="Display File Uploaded">
+      <bpmn:documentation># Is file uploaded
+uploaded:  {{uploaded}}</bpmn:documentation>
+      <bpmn:incoming>Flow_1gpekhi</bpmn:incoming>
+      <bpmn:outgoing>Flow_0qyam4h</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:scriptTask id="Activity_DeleteIRBDocument" name="Delete IRB Document">
+      <bpmn:incoming>Flow_0qyam4h</bpmn:incoming>
+      <bpmn:outgoing>Flow_1rexoi9</bpmn:outgoing>
+      <bpmn:script>delete_irb_document(irb_document=irb_document)</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:scriptTask id="Activity_CheckFileDeleted" name="Check File Deleted">
+      <bpmn:incoming>Flow_1rexoi9</bpmn:incoming>
+      <bpmn:outgoing>Flow_06hfqyd</bpmn:outgoing>
+      <bpmn:script>deleted = not is_file_uploaded(irb_document)</bpmn:script>
+    </bpmn:scriptTask>
+    <bpmn:sequenceFlow id="Flow_0qyam4h" sourceRef="Activity_DisplayFileUploaded" targetRef="Activity_DeleteIRBDocument" />
+    <bpmn:sequenceFlow id="Flow_06hfqyd" sourceRef="Activity_CheckFileDeleted" targetRef="Activity_DisplayFileDeleted" />
+    <bpmn:sequenceFlow id="Flow_0ry4bnx" sourceRef="Activity_DisplayFileDeleted" targetRef="Event_06rfn6m" />
+    <bpmn:manualTask id="Activity_DisplayFileDeleted" name="Display File Deleted">
+      <bpmn:documentation># Is file deleted
+deleted:  {{deleted}}</bpmn:documentation>
+      <bpmn:incoming>Flow_06hfqyd</bpmn:incoming>
+      <bpmn:outgoing>Flow_0ry4bnx</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_44b3aca">
+      <bpmndi:BPMNEdge id="Flow_0oyc3ye_di" bpmnElement="Flow_0oyc3ye">
+        <di:waypoint x="360" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1j6i6nv_di" bpmnElement="Flow_1j6i6nv">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="260" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1gpekhi_di" bpmnElement="Flow_1gpekhi">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="590" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0qyam4h_di" bpmnElement="Flow_0qyam4h">
+        <di:waypoint x="640" y="157" />
+        <di:waypoint x="640" y="220" />
+        <di:waypoint x="310" y="220" />
+        <di:waypoint x="310" y="280" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1rexoi9_di" bpmnElement="Flow_1rexoi9">
+        <di:waypoint x="360" y="320" />
+        <di:waypoint x="430" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_06hfqyd_di" bpmnElement="Flow_06hfqyd">
+        <di:waypoint x="530" y="320" />
+        <di:waypoint x="590" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0ry4bnx_di" bpmnElement="Flow_0ry4bnx">
+        <di:waypoint x="690" y="320" />
+        <di:waypoint x="742" y="320" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_176crcy_di" bpmnElement="Activity_WhichIRBDocument">
+        <dc:Bounds x="260" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0015703_di" bpmnElement="Activity_CheckFileUploaded">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1kmb6qu_di" bpmnElement="Activity_CheckFileDeleted">
+        <dc:Bounds x="430" y="280" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0om2kg5_di" bpmnElement="Activity_DeleteIRBDocument">
+        <dc:Bounds x="260" y="280" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_11nq3xj_di" bpmnElement="Activity_DisplayFileUploaded">
+        <dc:Bounds x="590" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0cbkkzl_di" bpmnElement="Activity_DisplayFileDeleted">
+        <dc:Bounds x="590" y="280" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_06rfn6m_di" bpmnElement="Event_06rfn6m">
+        <dc:Bounds x="742" y="302" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/data/pb_responses/user_studies.json
+++ b/tests/data/pb_responses/user_studies.json
@@ -3,7 +3,6 @@
     "DATE_MODIFIED": "2020-02-19T14:26:49.127756",
     "HSRNUMBER": "12345",
     "NETBADGEID": "dhf8r",
-    "Q_COMPLETE": true,
     "STUDYID": 54321,
     "TITLE": "Another study about the effect of a naked mannequin on software productivity"
   },
@@ -11,7 +10,6 @@
     "DATE_MODIFIED": "2020-02-19T14:24:55.101695",
     "HSRNUMBER": "",
     "NETBADGEID": "dhf8r",
-    "Q_COMPLETE": true,
     "STUDYID": 65432,
     "TITLE": "Peanut butter consumption among quiet dogs"
   },
@@ -19,7 +17,6 @@
     "DATE_MODIFIED": "2020-02-19T14:24:55.101695",
     "HSRNUMBER": "",
     "NETBADGEID": "dhf8r",
-    "Q_COMPLETE": false,
     "STUDYID": 1,
     "TITLE": "Efficacy of xenomorph bio-augmented circuits on dexterity of cybernetic prostheses"
   }

--- a/tests/test_protocol_builder.py
+++ b/tests/test_protocol_builder.py
@@ -1,7 +1,7 @@
+from tests.base_test import BaseTest
 from unittest.mock import patch
 
 from crc import app
-from tests.base_test import BaseTest
 from crc.services.protocol_builder import ProtocolBuilderService
 
 

--- a/tests/workflow/test_workflow_delete_irb_document.py
+++ b/tests/workflow/test_workflow_delete_irb_document.py
@@ -1,0 +1,39 @@
+from tests.base_test import BaseTest
+from crc.services.file_service import FileService
+from crc.scripts.is_file_uploaded import IsFileUploaded
+import io
+
+
+class TestDeleteIRBDocument(BaseTest):
+
+    def test_delete_irb_document(self):
+        self.load_example_data()
+        irb_code = 'Study_Protocol_Document'
+
+        workflow = self.create_workflow('add_delete_irb_document')
+        study_id = workflow.study_id
+
+        workflow_api = self.get_workflow_api(workflow)
+        first_task = workflow_api.next_task
+
+        files = FileService.get_files_for_study(study_id)
+        self.assertEqual(0, len(files))
+        self.assertEqual(False, IsFileUploaded.do_task(IsFileUploaded, first_task, study_id, workflow.id, irb_code))
+
+        # Add a file
+        FileService.add_workflow_file(workflow_id=workflow.id,
+                                      name="filename.txt", content_type="text",
+                                      binary_data=b'1234', irb_doc_code=irb_code)
+        self.assertEqual(True, IsFileUploaded.do_task(IsFileUploaded, first_task, study_id, workflow.id, irb_code))
+
+        self.complete_form(workflow, first_task, {'irb_document': irb_code})
+        workflow_api = self.get_workflow_api(workflow)
+        second_task = workflow_api.next_task
+        self.assertEqual('# Is file uploaded\nuploaded:  True', second_task.documentation)
+
+        self.complete_form(workflow, second_task, {})
+        workflow_api = self.get_workflow_api(workflow)
+        third_task = workflow_api.next_task
+        self.assertEqual('# Is file deleted\ndeleted:  True', third_task.documentation)
+
+        print('test_delete_irb_document')

--- a/tests/workflow/test_workflow_delete_irb_document.py
+++ b/tests/workflow/test_workflow_delete_irb_document.py
@@ -1,7 +1,7 @@
 from tests.base_test import BaseTest
+from crc.api.common import ApiError
 from crc.services.file_service import FileService
 from crc.scripts.is_file_uploaded import IsFileUploaded
-import io
 
 
 class TestDeleteIRBDocument(BaseTest):
@@ -16,6 +16,7 @@ class TestDeleteIRBDocument(BaseTest):
         workflow_api = self.get_workflow_api(workflow)
         first_task = workflow_api.next_task
 
+        # Should not have any files yet
         files = FileService.get_files_for_study(study_id)
         self.assertEqual(0, len(files))
         self.assertEqual(False, IsFileUploaded.do_task(IsFileUploaded, first_task, study_id, workflow.id, irb_code))
@@ -24,16 +25,57 @@ class TestDeleteIRBDocument(BaseTest):
         FileService.add_workflow_file(workflow_id=workflow.id,
                                       name="filename.txt", content_type="text",
                                       binary_data=b'1234', irb_doc_code=irb_code)
+        # Assert we have the file
         self.assertEqual(True, IsFileUploaded.do_task(IsFileUploaded, first_task, study_id, workflow.id, irb_code))
 
+        # The workflow checks whether the file is uploaded,
+        # and prints the result in documentation
         self.complete_form(workflow, first_task, {'irb_document': irb_code})
         workflow_api = self.get_workflow_api(workflow)
         second_task = workflow_api.next_task
         self.assertEqual('# Is file uploaded\nuploaded:  True', second_task.documentation)
 
+        # It then deletes the file, checks if file is deleted,
+        # and prints the result in documentation
         self.complete_form(workflow, second_task, {})
         workflow_api = self.get_workflow_api(workflow)
         third_task = workflow_api.next_task
         self.assertEqual('# Is file deleted\ndeleted:  True', third_task.documentation)
 
-        print('test_delete_irb_document')
+    def test_delete_irb_document_no_document(self):
+        self.load_example_data()
+        irb_code = 'Study_Protocol_Document'
+
+        workflow = self.create_workflow('add_delete_irb_document')
+
+        workflow_api = self.get_workflow_api(workflow)
+        first_task = workflow_api.next_task
+
+        # The workflow checks whether the file is uploaded,
+        # and prints the result in documentation
+        self.complete_form(workflow, first_task, {'irb_document': irb_code})
+        workflow_api = self.get_workflow_api(workflow)
+        second_task = workflow_api.next_task
+        self.assertEqual('# Is file uploaded\nuploaded:  False', second_task.documentation)
+
+        # There is no document to delete, so we get an error
+        with self.assertRaises(AssertionError) as ex:
+            self.complete_form(workflow, second_task, {})
+
+    def test_delete_irb_document_bad_document(self):
+        self.load_example_data()
+        # This is a bad document code
+        irb_code = 'Study_Protocol_Doc'
+
+        workflow = self.create_workflow('add_delete_irb_document')
+
+        workflow_api = self.get_workflow_api(workflow)
+        first_task = workflow_api.next_task
+
+        self.complete_form(workflow, first_task, {'irb_document': irb_code})
+        workflow_api = self.get_workflow_api(workflow)
+        second_task = workflow_api.next_task
+        self.assertEqual('# Is file uploaded\nuploaded:  False', second_task.documentation)
+
+        with self.assertRaises(AssertionError):
+            self.complete_form(workflow, second_task, {})


### PR DESCRIPTION
***This PR needs to be coordinated with #273 because of removing Q_COMPLETE as a column in PB Mock study table***

This PR adds the script `delete_irb_document` to delete an IRB document, or list of documents

Added 3 files:
- crc/scripts/delete_irb_document.py
- tests/data/add_delete_irb_document/add_delete_irb_document.bpmn
- tests/workflow/test_workflow_delete_irb_document.py

Modified some files because of ticket 273 where we removed Q_COMPLETE as a column in PB Mock study table