### PR TITLE
Make sure we are using the correct script engine

### DIFF
--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -206,6 +206,7 @@ def update_task(workflow_id, task_id, body, terminate_loop=None, update_all=Fals
     processor = WorkflowProcessor(workflow_model)
     task_id = uuid.UUID(task_id)
     spiff_task = processor.bpmn_workflow.get_task(task_id)
+    spiff_task.workflow.script_engine = processor.bpmn_workflow.script_engine
     _verify_user_and_role(processor, spiff_task)
     user = UserService.current_user(allow_admin_impersonate=False) # Always log as the real user.
 


### PR DESCRIPTION
This fixes problems that Alex was having with a call activity - 

My memory is that after it serializes, it was pulling it back in, but not correctly setting the custom script engine that we are using in workflow, so this takes care of that. 