### PR TITLE
337 partial fix

### DIFF
--- a/crc/scripts/file_data_set.py
+++ b/crc/scripts/file_data_set.py
@@ -3,6 +3,7 @@ from flask import g
 from crc.api.common import ApiError
 from crc.scripts.data_store_base import DataStoreBase
 from crc.scripts.script import Script
+from crc.services.file_service import FileService
 
 
 class FileDataSet(Script, DataStoreBase):
@@ -34,8 +35,19 @@ class FileDataSet(Script, DataStoreBase):
     def do_task(self, task, study_id, workflow_id, *args, **kwargs):
         if self.validate_kw_args(**kwargs):
             myargs = [kwargs['key'],kwargs['value']]
-        fileid = kwargs['file_id']
+
+        try:
+            fileid = int(kwargs['file_id'])
+        except:
+            raise ApiError("invalid_file_id",
+                           "Attempting to update DataStore for an invalid fileid '%s'" % kwargs['file_id'])
+
         del(kwargs['file_id'])
+        if kwargs['key'] == 'irb_code':
+            irb_doc_code = kwargs['value']
+            FileService.update_irb_code(fileid,irb_doc_code)
+
+
         return self.set_data_common(task.id,
                                     None,
                                     None,

--- a/crc/services/file_service.py
+++ b/crc/services/file_service.py
@@ -97,6 +97,27 @@ class FileService(object):
         review = any([f.is_review for f in files])
         return review
 
+    @staticmethod
+    def update_irb_code(file_id, irb_doc_code):
+        """Create a new file and associate it with the workflow
+        Please note that the irb_doc_code MUST be a known file in the irb_documents.xslx reference document."""
+        if not FileService.is_allowed_document(irb_doc_code):
+            raise ApiError("invalid_form_field_key",
+                           "When uploading files, the form field id must match a known document in the "
+                           "irb_docunents.xslx reference file.  This code is not found in that file '%s'" % irb_doc_code)
+
+        """ """
+        file_model = session.query(FileModel)\
+            .filter(FileModel.id == file_id).first()
+        if file_model is None:
+            raise ApiError("invalid_file_id",
+                           "When updating the irb_doc_code for a file, that file_id must already exist "
+                           "This file_id is not found in the database '%d'" % file_id)
+
+        file_model.irb_doc_code = irb_doc_code
+        session.commit()
+        return True
+
 
     @staticmethod
     def add_workflow_file(workflow_id, irb_doc_code, name, content_type, binary_data):


### PR DESCRIPTION
if the user calls the file_data_set function for a valid file with the key 'irb_code' and a value of a valid IRB document code, then we should set the irb code on the file.

fixes #337 (paritally)