### PR TITLE
Datastore file endpoints #325

### DIFF
--- a/crc/api.yml
+++ b/crc/api.yml
@@ -1372,6 +1372,27 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DataStore"
+  /datastore/file/{file_id}:
+    parameters:
+      - name: file_id
+        in: path
+        required: true
+        description: The file id we are concerned with
+        schema:
+          type: string
+          format: string
+    get:
+      operationId: crc.api.data_store.file_multi_get
+      summary: Gets all datastore items by file_id
+      tags:
+        - DataStore
+      responses:
+        '200':
+          description: Get all values from the data store for a file_id
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DataStore"
 components:
   securitySchemes:
     jwt:

--- a/crc/api/data_store.py
+++ b/crc/api/data_store.py
@@ -5,7 +5,7 @@ from crc import session
 from crc.api.common import ApiError
 from crc.models.data_store import DataStoreModel, DataStoreSchema
 from crc.scripts.data_store_base import DataStoreBase
-from crc.models.file import FileModel
+
 
 def study_multi_get(study_id):
     """Get all data_store values for a given study_id study"""

--- a/crc/api/data_store.py
+++ b/crc/api/data_store.py
@@ -5,7 +5,7 @@ from crc import session
 from crc.api.common import ApiError
 from crc.models.data_store import DataStoreModel, DataStoreSchema
 from crc.scripts.data_store_base import DataStoreBase
-
+from crc.models.file import FileModel
 
 def study_multi_get(study_id):
     """Get all data_store values for a given study_id study"""
@@ -26,6 +26,16 @@ def user_multi_get(user_id):
     dsb = DataStoreBase()
     retval = dsb.get_multi_common(None,
                                   user_id)
+    results = DataStoreSchema(many=True).dump(retval)
+    return results
+
+
+def file_multi_get(file_id):
+    """Get all data values in the data store for a file_id"""
+    if file_id is None:
+        raise ApiError(code='unknown_file', message='Please provide a valid file id.')
+    dsb = DataStoreBase()
+    retval = dsb.get_multi_common(None, None, file_id=file_id)
     results = DataStoreSchema(many=True).dump(retval)
     return results
 

--- a/crc/models/data_store.py
+++ b/crc/models/data_store.py
@@ -25,4 +25,5 @@ class DataStoreSchema(SQLAlchemyAutoSchema):
     class Meta:
         model = DataStoreModel
         load_instance = True
+        include_fk = True
         sqla_session = db.session


### PR DESCRIPTION
Adding an endpoint to DataStore API for files, just like study and user.

Pretty straight forward:
- endpoint in api.yml
- method in crc.api.data_store
- tests in tests/test_data_store_api

Also added fix to DataStoreSchema to recognize foreign key column in crc.models.data_store