### PR TITLE
Ldap issues #394

### DIFF
--- a/crc/scripts/ldap.py
+++ b/crc/scripts/ldap.py
@@ -48,21 +48,29 @@ supervisor_info = ldap(supervisor_uid)   // Sets the supervisor information to l
                                    "UID for the person we want to look up.")
         if len(args) < 1:
             if UserService.has_user():
-               uid = UserService.current_user().uid
+                uid = UserService.current_user().uid
         else:
             uid = args[0]
-        user_info = LdapService.user_info(uid)
-        user_info_dict = {
-            "display_name": user_info.display_name,
-            "given_name": user_info.given_name,
-            "email_address": user_info.email_address,
-            "telephone_number": user_info.telephone_number,
-            "title": user_info.title,
-            "department": user_info.department,
-            "affiliation": user_info.affiliation,
-            "sponsor_type": user_info.sponsor_type,
-            "uid": user_info.uid,
-            "proper_name": user_info.proper_name()
-        }
 
-        return user_info_dict
+        try:
+            user_info = LdapService.user_info(uid)
+        except ApiError as ae:
+            app.logger.info(ae)
+            return {}
+        except Exception as e:
+            app.logger.info(e)
+            return {}
+        else:
+            user_info_dict = {
+                "display_name": user_info.display_name,
+                "given_name": user_info.given_name,
+                "email_address": user_info.email_address,
+                "telephone_number": user_info.telephone_number,
+                "title": user_info.title,
+                "department": user_info.department,
+                "affiliation": user_info.affiliation,
+                "sponsor_type": user_info.sponsor_type,
+                "uid": user_info.uid,
+                "proper_name": user_info.proper_name()
+            }
+            return user_info_dict

--- a/crc/services/ldap_service.py
+++ b/crc/services/ldap_service.py
@@ -58,6 +58,7 @@ class LdapService(object):
 
     @staticmethod
     def user_info(uva_uid):
+        uva_uid = uva_uid.lower()
         user_info = db.session.query(LdapModel).filter(LdapModel.uid == uva_uid).first()
         if not user_info:
             app.logger.info("No cache for " + uva_uid)

--- a/tests/ldap/test_ldap_lookup_script.py
+++ b/tests/ldap/test_ldap_lookup_script.py
@@ -45,8 +45,8 @@ class TestLdapLookupScript(BaseTest):
         }
 
         script = Ldap()
-        with(self.assertRaises(ApiError)):
-            user_details = script.do_task(task, workflow.study_id, workflow.id, "PIComputingID")
+        user_details = script.do_task(task, workflow.study_id, workflow.id, "PIComputingID")
+        self.assertEqual({}, user_details)
 
     def test_get_current_user_details(self):
         self.load_example_data()

--- a/tests/test_ldap_service.py
+++ b/tests/test_ldap_service.py
@@ -31,3 +31,8 @@ class TestLdapService(BaseTest):
             self.assertFalse(True, "An API error should be raised.")
         except ApiError as ae:
             self.assertEqual("missing_ldap_record", ae.code)
+
+    def test_get_user_with_caps(self):
+        user_info = LdapService.user_info("LB3DP")
+        self.assertIsNotNone(user_info)
+        self.assertEqual("lb3dp", user_info.uid)


### PR DESCRIPTION
Fixed an issue with LDAP where capitalized UIDs caused a Postgres unique value error.
Also, we now return an empty dictionary when we don't get a record back instead, of returning the ApiError