### PR TITLE
fixes #346, allow emails to fire in scheduled events

### DIFF
--- a/crc/services/email_service.py
+++ b/crc/services/email_service.py
@@ -68,4 +68,5 @@ class EmailService(object):
 
     @staticmethod
     def get_cr_connect_wrapper(email_body):
-        return render_template('mail_content_template.html', email_body=email_body, base_url=request.base_url)
+        base_url = app.config['FRONTEND']  # The frontend url
+        return render_template('mail_content_template.html', email_body=email_body, base_url=base_url)


### PR DESCRIPTION
We were depending on an active http request existing in order to fire… emails, using that request to determine the front end url.  We have the frontend url in our config file, and we don't have a request object when running scheduled tasks, so I just use our configuration setting instead.