### PR TITLE
413 library cleanup

### DIFF
--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -138,7 +138,7 @@ def delete_workflow_specification(spec_id):
     # Delete all events and workflow models related to this specification
     for workflow in session.query(WorkflowModel).filter_by(workflow_spec_id=spec_id):
         StudyService.delete_workflow(workflow.id)
-    # the cascade feature doesn't work if
+    # .delete() doesn't work when we need a cascade. Must grab the record, and explicitly delete
     deleteSpec = session.query(WorkflowSpecModel).filter_by(id=spec_id).first()
     session.delete(deleteSpec)
     session.commit()

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -138,7 +138,9 @@ def delete_workflow_specification(spec_id):
     # Delete all events and workflow models related to this specification
     for workflow in session.query(WorkflowModel).filter_by(workflow_spec_id=spec_id):
         StudyService.delete_workflow(workflow.id)
-    session.query(WorkflowSpecModel).filter_by(id=spec_id).delete()
+    # the cascade feature doesn't work if
+    deleteSpec = session.query(WorkflowSpecModel).filter_by(id=spec_id).first()
+    session.delete(deleteSpec)
     session.commit()
 
 

--- a/crc/models/workflow.py
+++ b/crc/models/workflow.py
@@ -4,6 +4,7 @@ import marshmallow
 from marshmallow import EXCLUDE,fields
 from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 from sqlalchemy import func
+from sqlalchemy.orm import backref
 
 from crc import db
 from crc.models.file import FileModel, FileDataModel
@@ -46,9 +47,9 @@ class WorkflowLibraryModel(db.Model):
    library_spec_id = db.Column(db.String, db.ForeignKey('workflow_spec.id'), nullable=True)
    parent = db.relationship(WorkflowSpecModel,
                                    primaryjoin=workflow_spec_id==WorkflowSpecModel.id,
-                                  backref='libraries')
+                                  backref=backref('libraries',cascade='all, delete'))
    library = db.relationship(WorkflowSpecModel,primaryjoin=library_spec_id==WorkflowSpecModel.id,
-                                  backref='parents')
+                                  backref=backref('parents',cascade='all, delete'))
 
 
 class WorkflowSpecModelSchema(SQLAlchemyAutoSchema):

--- a/tests/test_workflow_api.py
+++ b/tests/test_workflow_api.py
@@ -1,3 +1,4 @@
+from crc.models.workflow import WorkflowLibraryModel
 from tests.base_test import BaseTest
 
 from crc import session
@@ -60,5 +61,34 @@ class TestWorkflowApi(BaseTest):
         self.assertIsNotNone(returned.get('libraries'))
         self.assertEqual(len(returned['libraries']),0)
 
+    def test_library_cleanup(self):
+        self.load_example_data()
+        spec1 = ExampleDataLoader().create_spec('hello_world', 'Hello World', category_id=0, library=False,
+                                               from_tests=True)
+
+        spec2 = ExampleDataLoader().create_spec('hello_world_lib', 'Hello World Library', category_id=0, library=True,
+                                               from_tests=True)
+        user = session.query(UserModel).first()
+        self.assertIsNotNone(user)
+
+        rv = self.app.post(f'/v1.0/workflow-specification/%s/library/%s'%(spec1.id,spec2.id),
+                          follow_redirects=True,
+                          content_type="application/json",
+                          headers=self.logged_in_headers())
+        self.assert_success(rv)
+
+        rv = self.app.get(f'/v1.0/workflow-specification/%s'%spec1.id,follow_redirects=True,
+                          content_type="application/json",
+                          headers=self.logged_in_headers())
+        returned=rv.json
+        lib = session.query(WorkflowLibraryModel).filter(WorkflowLibraryModel.library_spec_id==spec2.id).first()
+        self.assertIsNotNone(lib)
+
+        rv = self.app.delete(f'/v1.0/workflow-specification/%s'%(spec1.id),follow_redirects=True,
+                          content_type="application/json",
+                          headers=self.logged_in_headers())
+
+        lib = session.query(WorkflowLibraryModel).filter(WorkflowLibraryModel.library_spec_id==spec2.id).first()
+        self.assertIsNone(lib)
 
 


### PR DESCRIPTION
Fixes #413 - adds a backref cascade/delete and changes the way the delete happens so the SQLAlchemy magic happens - 
So this is a software cascade rather than a database defined cascade. 