### PR TITLE
Add reorder api endpoints #444

### DIFF
--- a/crc/api.yml
+++ b/crc/api.yml
@@ -568,6 +568,36 @@ paths:
       responses:
         '204':
           description: The workflow specification has been removed.
+  /workflow-specification/{spec_id}/reorder:
+    parameters:
+      - name: spec_id
+        in: path
+        required: true
+        description: The unique id of an existing workflow specification to validate.
+        schema:
+          type: string
+      - name: direction
+        in: query
+        required: true
+        description: The direction we want to move the spec - `up` or `down`
+        schema:
+          type: string
+          example: up
+    put:
+      operationId: crc.api.workflow.reorder_workflow_specification
+      summary: Move the workflow spec up or down in the display order
+      tags:
+        - Workflow Specifications
+      responses:
+        '200':
+          description: An array of workflow specifications
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowSpec"
+
   /workflow-specification/{spec_id}/validate:
     parameters:
       - name: spec_id
@@ -685,6 +715,35 @@ paths:
       responses:
         '204':
           description: The workflow spec category has been removed.
+  /workflow-specification-category/{cat_id}/reorder:
+    parameters:
+      - name: cat_id
+        in: path
+        required: true
+        description: The unique id of an existing workflow spec category to modify.
+        schema:
+          type: string
+      - name: direction
+        in: query
+        required: true
+        description: The direction you want to move the category - `up` or `down`
+        schema:
+          type: string
+          example: up
+    put:
+      operationId: crc.api.workflow.reorder_workflow_spec_category
+      summary: Move the workflow spec category up or down in the display order
+      tags:
+        - Workflow Specification Category
+      responses:
+        '200':
+          description: An array of workflow spec categories
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/WorkflowSpecCategory"
   /file:
     parameters:
       - name: workflow_spec_id

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -145,16 +145,7 @@ def delete_workflow_specification(spec_id):
     session.commit()
 
     # Reorder the remaining specs
-    new_order = 0
-    wf_specs = session.query(WorkflowSpecModel).\
-        filter(WorkflowSpecModel.category_id == category_id).\
-        order_by(WorkflowSpecModel.display_order).\
-        all()
-    for wf_spec_model in wf_specs:
-        wf_spec_model.display_order = new_order
-        session.add(wf_spec_model)
-        new_order += 1
-    session.commit()
+    WorkflowService.cleanup_workflow_spec_display_order()
 
 
 def reorder_workflow_specification(spec_id, direction):
@@ -354,13 +345,7 @@ def delete_workflow_spec_category(cat_id):
     session.query(WorkflowSpecCategoryModel).filter_by(id=cat_id).delete()
     session.commit()
     # Reorder the remaining categories
-    remaining = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
-    new_order = 0
-    for category_model in remaining:
-        category_model.display_order = new_order
-        session.add(category_model)
-        new_order += 1
-    session.commit()
+    WorkflowService.cleanup_workflow_spec_category_display_order()
 
 
 def reorder_workflow_spec_category(cat_id, direction):

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -161,6 +161,7 @@ def reorder_workflow_specification(spec_id, direction):
                        message='The direction must be `up` or `down`.')
     spec = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.id == spec_id).first()
     if spec:
+        WorkflowService.cleanup_workflow_spec_display_order(spec.category_id)
         ordered_specs = WorkflowService.reorder_workflow_spec(spec, direction)
     else:
         raise ApiError(code='bad_spec_id',
@@ -366,6 +367,7 @@ def reorder_workflow_spec_category(cat_id, direction):
     if direction not in ('up', 'down'):
         raise ApiError(code='bad_direction',
                        message='The direction must be `up` or `down`.')
+    WorkflowService.cleanup_workflow_spec_category_display_order()
     category = session.query(WorkflowSpecCategoryModel).\
         filter(WorkflowSpecCategoryModel.id == cat_id).first()
     if category:

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -39,6 +39,7 @@ def all_specifications(libraries=False,standalone=False):
 
 
 def add_workflow_specification(body):
+    WorkflowService.cleanup_workflow_spec_display_order()
     count = session.query(WorkflowSpecModel).filter_by(category_id=body['category_id']).count()
     body['display_order'] = count
     new_spec: WorkflowSpecModel = WorkflowSpecModelSchema().load(body, session=session)
@@ -323,6 +324,9 @@ def get_workflow_spec_category(cat_id):
 
 
 def add_workflow_spec_category(body):
+    WorkflowService.cleanup_workflow_spec_category_display_order()
+    count = session.query(WorkflowSpecCategoryModel).count()
+    body['display_order'] = count
     schema = WorkflowSpecCategoryModelSchema()
     new_cat: WorkflowSpecCategoryModel = schema.load(body, session=session)
     session.add(new_cat)

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -145,7 +145,24 @@ def delete_workflow_specification(spec_id):
 
 
 def reorder_workflow_specification(spec_id, direction):
-    pass
+    # TODO: Need to return list of specs
+    # TODO: Maybe move some of this code to services.workflow_service
+    if direction not in ('up', 'down'):
+        raise ApiError(code='bad_direction',
+                       message='The direction must be `up` or `down`.')
+    spec = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.id == spec_id).first()
+    category_id = spec.category_id
+    if direction == 'up':
+        neighbor = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.category_id == category_id).filter(WorkflowSpecModel.display_order == spec.display_order - 1).first()
+        neighbor.display_order += 1
+        spec.display_order -= 1
+    if direction == 'down':
+        neighbor = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.category_id == category_id).filter(WorkflowSpecModel.display_order == spec.display_order + 1).first()
+        neighbor.display_order -= 1
+        spec.display_order += 1
+    session.add(spec)
+    session.add(neighbor)
+    session.commit()
 
 
 def get_workflow_from_spec(spec_id):

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -39,8 +39,9 @@ def all_specifications(libraries=False,standalone=False):
 
 
 def add_workflow_specification(body):
-    WorkflowService.cleanup_workflow_spec_display_order()
-    count = session.query(WorkflowSpecModel).filter_by(category_id=body['category_id']).count()
+    category_id = body['category_id']
+    WorkflowService.cleanup_workflow_spec_display_order(category_id)
+    count = session.query(WorkflowSpecModel).filter_by(category_id=category_id).count()
     body['display_order'] = count
     new_spec: WorkflowSpecModel = WorkflowSpecModelSchema().load(body, session=session)
     session.add(new_spec)
@@ -151,7 +152,7 @@ def delete_workflow_specification(spec_id):
     session.commit()
 
     # Reorder the remaining specs
-    WorkflowService.cleanup_workflow_spec_display_order()
+    WorkflowService.cleanup_workflow_spec_display_order(category_id)
 
 
 def reorder_workflow_specification(spec_id, direction):

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -353,6 +353,13 @@ def update_workflow_spec_category(cat_id, body):
 def delete_workflow_spec_category(cat_id):
     session.query(WorkflowSpecCategoryModel).filter_by(id=cat_id).delete()
     session.commit()
+    # Reorder the remaining categories
+    remaining = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+    new_order = 0
+    for category_model in remaining:
+        category_model.display_order = new_order
+        session.add(category_model)
+        new_order += 1
 
 
 def reorder_workflow_spec_category(cat_id, direction):

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -104,6 +104,7 @@ def validate_workflow_specification(spec_id, study_id=None, test_until=None):
         return ApiErrorSchema(many=True).dump([error])
     return []
 
+
 def update_workflow_specification(spec_id, body):
     if spec_id is None:
         raise ApiError('unknown_spec', 'Please provide a valid Workflow Spec ID.')
@@ -111,6 +112,10 @@ def update_workflow_specification(spec_id, body):
 
     if spec is None:
         raise ApiError('unknown_study', 'The spec "' + spec_id + '" is not recognized.')
+
+    # Make sure they don't try to change the display_order
+    # There is a separate endpoint for this
+    body['display_order'] = spec.display_order
 
     schema = WorkflowSpecModelSchema()
     spec = schema.load(body, session=session, instance=spec, partial=True)
@@ -333,6 +338,10 @@ def update_workflow_spec_category(cat_id, body):
 
     if category is None:
         raise ApiError('unknown_category', 'The category "' + cat_id + '" is not recognized.')
+
+    # Make sure they don't try to change the display_order
+    # There is a separate endpoint for that
+    body['display_order'] = category.display_order
 
     schema = WorkflowSpecCategoryModelSchema()
     category = schema.load(body, session=session, instance=category, partial=True)

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -343,7 +343,18 @@ def delete_workflow_spec_category(cat_id):
 
 
 def reorder_workflow_spec_category(cat_id, direction):
-    pass
+    if direction not in ('up', 'down'):
+        raise ApiError(code='bad_direction',
+                       message='The direction must be `up` or `down`.')
+    category = session.query(WorkflowSpecCategoryModel).\
+        filter(WorkflowSpecCategoryModel.id == cat_id).first()
+    if category:
+        ordered_categories = WorkflowService.reorder_workflow_spec_category(category, direction)
+        schema = WorkflowSpecCategoryModelSchema(many=True)
+        return schema.dump(ordered_categories)
+    else:
+        return ApiError(code='bad_category_id',
+                        message=f'The category id {cat_id} did not return a Workflow Spec Category. Make sure it is a valid ID.')
 
 
 def lookup(workflow_id, task_spec_name, field_id, query=None, value=None, limit=10):

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -360,6 +360,7 @@ def delete_workflow_spec_category(cat_id):
         category_model.display_order = new_order
         session.add(category_model)
         new_order += 1
+    session.commit()
 
 
 def reorder_workflow_spec_category(cat_id, direction):

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -144,6 +144,10 @@ def delete_workflow_specification(spec_id):
     session.commit()
 
 
+def reorder_workflow_specification(spec_id, direction):
+    pass
+
+
 def get_workflow_from_spec(spec_id):
     workflow_model = WorkflowService.get_workflow_from_spec(spec_id, g.user)
     processor = WorkflowProcessor(workflow_model)
@@ -326,6 +330,10 @@ def update_workflow_spec_category(cat_id, body):
 def delete_workflow_spec_category(cat_id):
     session.query(WorkflowSpecCategoryModel).filter_by(id=cat_id).delete()
     session.commit()
+
+
+def reorder_workflow_spec_category(cat_id, direction):
+    pass
 
 
 def lookup(workflow_id, task_spec_name, field_id, query=None, value=None, limit=10):

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -145,24 +145,17 @@ def delete_workflow_specification(spec_id):
 
 
 def reorder_workflow_specification(spec_id, direction):
-    # TODO: Need to return list of specs
-    # TODO: Maybe move some of this code to services.workflow_service
     if direction not in ('up', 'down'):
         raise ApiError(code='bad_direction',
                        message='The direction must be `up` or `down`.')
     spec = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.id == spec_id).first()
-    category_id = spec.category_id
-    if direction == 'up':
-        neighbor = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.category_id == category_id).filter(WorkflowSpecModel.display_order == spec.display_order - 1).first()
-        neighbor.display_order += 1
-        spec.display_order -= 1
-    if direction == 'down':
-        neighbor = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.category_id == category_id).filter(WorkflowSpecModel.display_order == spec.display_order + 1).first()
-        neighbor.display_order -= 1
-        spec.display_order += 1
-    session.add(spec)
-    session.add(neighbor)
-    session.commit()
+    if spec:
+        ordered_specs = WorkflowService.reorder_workflow_spec(spec, direction)
+    else:
+        raise ApiError(code='bad_spec_id',
+                       message=f'The spec_id {spec_id} did not return a specification. Please check that it is valid.')
+    schema = WorkflowSpecModelSchema(many=True)
+    return schema.dump(ordered_specs)
 
 
 def get_workflow_from_spec(spec_id):

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -353,8 +353,8 @@ def reorder_workflow_spec_category(cat_id, direction):
         schema = WorkflowSpecCategoryModelSchema(many=True)
         return schema.dump(ordered_categories)
     else:
-        return ApiError(code='bad_category_id',
-                        message=f'The category id {cat_id} did not return a Workflow Spec Category. Make sure it is a valid ID.')
+        raise ApiError(code='bad_category_id',
+                       message=f'The category id {cat_id} did not return a Workflow Spec Category. Make sure it is a valid ID.')
 
 
 def lookup(workflow_id, task_spec_name, field_id, query=None, value=None, limit=10):

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -987,10 +987,11 @@ class WorkflowService(object):
         return ordered_categories
 
     @staticmethod
-    def cleanup_workflow_spec_display_order():
+    def cleanup_workflow_spec_display_order(category_id):
         # make sure we don't have gaps in display_order
         new_order = 0
         specs = session.query(WorkflowSpecModel).\
+            filter(WorkflowSpecModel.category_id == category_id).\
             order_by(WorkflowSpecModel.display_order).all()
         for spec in specs:
             spec.display_order = new_order

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -940,18 +940,21 @@ class WorkflowService(object):
                 filter(WorkflowSpecModel.category_id == category_id). \
                 filter(WorkflowSpecModel.display_order == spec.display_order - 1). \
                 first()
-            neighbor.display_order += 1
-            spec.display_order -= 1
+            if neighbor:
+                neighbor.display_order += 1
+                spec.display_order -= 1
         if direction == 'down':
             neighbor = session.query(WorkflowSpecModel). \
                 filter(WorkflowSpecModel.category_id == category_id). \
                 filter(WorkflowSpecModel.display_order == spec.display_order + 1). \
                 first()
-            neighbor.display_order -= 1
-            spec.display_order += 1
-        session.add(spec)
-        session.add(neighbor)
-        session.commit()
+            if neighbor:
+                neighbor.display_order -= 1
+                spec.display_order += 1
+        if neighbor:
+            session.add(spec)
+            session.add(neighbor)
+            session.commit()
         ordered_specs = session.query(WorkflowSpecModel). \
             filter(WorkflowSpecModel.category_id == category_id). \
             order_by(WorkflowSpecModel.display_order).all()
@@ -965,17 +968,20 @@ class WorkflowService(object):
             neighbor = session.query(WorkflowSpecCategoryModel).\
                 filter(WorkflowSpecCategoryModel.display_order == category.display_order - 1).\
                 first()
-            neighbor.display_order += 1
-            category.display_order -= 1
+            if neighbor:
+                neighbor.display_order += 1
+                category.display_order -= 1
         if direction == 'down':
             neighbor = session.query(WorkflowSpecCategoryModel).\
                 filter(WorkflowSpecCategoryModel.display_order == category.display_order + 1).\
                 first()
-            neighbor.display_order -= 1
-            category.display_order += 1
-        session.add(neighbor)
-        session.add(category)
-        session.commit()
+            if neighbor:
+                neighbor.display_order -= 1
+                category.display_order += 1
+        if neighbor:
+            session.add(neighbor)
+            session.add(category)
+            session.commit()
         ordered_categories = session.query(WorkflowSpecCategoryModel).\
             order_by(WorkflowSpecCategoryModel.display_order).all()
         return ordered_categories

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -985,3 +985,27 @@ class WorkflowService(object):
         ordered_categories = session.query(WorkflowSpecCategoryModel).\
             order_by(WorkflowSpecCategoryModel.display_order).all()
         return ordered_categories
+
+    @staticmethod
+    def cleanup_workflow_spec_display_order():
+        # make sure we don't have gaps in display_order
+        new_order = 0
+        specs = session.query(WorkflowSpecModel).\
+            order_by(WorkflowSpecModel.display_order).all()
+        for spec in specs:
+            spec.display_order = new_order
+            session.add(spec)
+            new_order += 1
+        session.commit()
+
+    @staticmethod
+    def cleanup_workflow_spec_category_display_order():
+        # make sure we don't have gaps in display_order
+        new_order = 0
+        categories = session.query(WorkflowSpecCategoryModel).\
+            order_by(WorkflowSpecCategoryModel.display_order).all()
+        for category in categories:
+            category.display_order = new_order
+            session.add(category)
+            new_order += 1
+        session.commit()

--- a/example_data.py
+++ b/example_data.py
@@ -267,6 +267,7 @@ class ExampleDataLoader:
                          display_name="Random Fact",
                          description="The workflow for a Random Fact.",
                          category_id=0,
+                         display_order=0,
                          master_spec=False,
                          from_tests=True)
 

--- a/tests/workflow/test_workflow_spec_api.py
+++ b/tests/workflow/test_workflow_spec_api.py
@@ -119,6 +119,7 @@ class TestWorkflowSpec(BaseTest):
         session.add(spec_model_1)
         session.add(spec_model_2)
         session.add(spec_model_3)
+        session.commit()
 
         self.app.delete('/v1.0/workflow-specification/test_spec_2', headers=self.logged_in_headers())
 
@@ -130,8 +131,6 @@ class TestWorkflowSpec(BaseTest):
         for test_spec in specs:
             self.assertEqual(test_order, test_spec.display_order)
             test_order += 1
-
-        print('test_order_after_delete_spec')
 
     def test_get_standalone_workflow_specs(self):
         self.load_example_data()
@@ -190,3 +189,35 @@ class TestWorkflowSpec(BaseTest):
         self.assert_success(rv)
         json_data = json.loads(rv.get_data(as_text=True))
         self.assertEqual(new_category_name, json_data['name'])
+
+    def test_delete_workflow_spec_category(self):
+        self.load_example_data()
+        category_model_1 = WorkflowSpecCategoryModel(
+            id=1,
+            name='test_category_1',
+            display_name='Test Category 1',
+            display_order=1
+        )
+        category_model_2 = WorkflowSpecCategoryModel(
+            id=2,
+            name='test_category_2',
+            display_name='Test Category 2',
+            display_order=2
+        )
+        category_model_3 = WorkflowSpecCategoryModel(
+            id=3,
+            name='test_category_3',
+            display_name='Test Category 3',
+            display_order=3
+        )
+        session.add(category_model_1)
+        session.add(category_model_2)
+        session.add(category_model_3)
+        session.commit()
+
+        self.app.delete('/v1.0/workflow-spec-category/2', headers=self.logged_in_headers())
+        test_order = 0
+        categories = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+        for test_category in categories:
+            self.assertEqual(test_order, test_category.display_order)
+            test_order += 1

--- a/tests/workflow/test_workflow_spec_api.py
+++ b/tests/workflow/test_workflow_spec_api.py
@@ -104,6 +104,35 @@ class TestWorkflowSpec(BaseTest):
         num_workflows_after = session.query(WorkflowModel).filter_by(workflow_spec_id=spec_id).count()
         self.assertEqual(num_files_after + num_workflows_after, 0)
 
+    def test_display_order_after_delete_spec(self):
+        self.load_example_data()
+        workflow_spec_category = session.query(WorkflowSpecCategoryModel).first()
+        spec_model_1 = WorkflowSpecModel(id='test_spec_1', name='test_spec_1', display_name='Test Spec 1',
+                                         description='Test Spec 1 Description', category_id=workflow_spec_category.id,
+                                         display_order=1, standalone=False)
+        spec_model_2 = WorkflowSpecModel(id='test_spec_2', name='test_spec_2', display_name='Test Spec 2',
+                                         description='Test Spec 2 Description', category_id=workflow_spec_category.id,
+                                         display_order=2, standalone=False)
+        spec_model_3 = WorkflowSpecModel(id='test_spec_3', name='test_spec_3', display_name='Test Spec 3',
+                                         description='Test Spec 3 Description', category_id=workflow_spec_category.id,
+                                         display_order=3, standalone=False)
+        session.add(spec_model_1)
+        session.add(spec_model_2)
+        session.add(spec_model_3)
+
+        self.app.delete('/v1.0/workflow-specification/test_spec_2', headers=self.logged_in_headers())
+
+        test_order = 0
+        specs = session.query(WorkflowSpecModel).\
+            filter(WorkflowSpecModel.category_id == workflow_spec_category.id).\
+            order_by(WorkflowSpecModel.display_order).\
+            all()
+        for test_spec in specs:
+            self.assertEqual(test_order, test_spec.display_order)
+            test_order += 1
+
+        print('test_order_after_delete_spec')
+
     def test_get_standalone_workflow_specs(self):
         self.load_example_data()
         category = session.query(WorkflowSpecCategoryModel).first()

--- a/tests/workflow/test_workflow_spec_category_reorder.py
+++ b/tests/workflow/test_workflow_spec_category_reorder.py
@@ -107,3 +107,64 @@ class TestWorkflowSpecCategoryReorder(BaseTest):
         reordered = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
         self.assertEqual(ordered, reordered)
 
+    def test_workflow_spec_category_up_too_far(self):
+        self.load_example_data()
+        self._load_test_categories()
+        ordered = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+
+        # Try to move 0 up
+        rv = self.app.put(f"/v1.0/workflow-specification-category/0/reorder?direction=up",
+                          headers=self.logged_in_headers())
+        # Make sure we don't get an error
+        self.assert_success(rv)
+
+        # Make sure we get the original list back.
+        reordered = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+        self.assertEqual(ordered, reordered)
+
+    def test_workflow_spec_category_bad_order(self):
+        self.load_example_data()
+        self._load_test_categories()
+        ordered = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+        # Create bad display_orders
+        # 3 of them have 1 as their display_order
+        wf_spec_category_model = ordered[0]
+        wf_spec_category_model.display_order = 1
+        session.add(wf_spec_category_model)
+        wf_spec_category_model = ordered[1]
+        wf_spec_category_model.display_order = 1
+        session.add(wf_spec_category_model)
+        wf_spec_category_model = ordered[2]
+        wf_spec_category_model.display_order = 1
+        session.add(wf_spec_category_model)
+        session.commit()
+
+        bad_ordered = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+        # Confirm the bad display_orders
+        self.assertEqual('Test Category 1', bad_ordered[0].display_name)
+        self.assertEqual(1, bad_ordered[0].display_order)
+        self.assertEqual('Test Category', bad_ordered[1].display_name)
+        self.assertEqual(1, bad_ordered[1].display_order)
+        self.assertEqual('Test Category 2', bad_ordered[2].display_name)
+        self.assertEqual(1, bad_ordered[2].display_order)
+        self.assertEqual('Test Category 3', bad_ordered[3].display_name)
+        self.assertEqual(3, bad_ordered[3].display_order)
+
+        # Reorder 2 up
+        # This should cause a cleanup of the display_orders
+        # I don't know how Postgres/SQLAlchemy determine the order when
+        # multiple categories have the same display_order
+        # But, it ends up
+        # Test Category 1, Test Category, Test Category 2, Test Category 3
+        # So, after moving 2 up, we should end up with
+        # Test Category 1, Test Category 2, Test Category, Test Category 3
+        rv = self.app.put(f"/v1.0/workflow-specification-category/2/reorder?direction=up",
+                          headers=self.logged_in_headers())
+        self.assertEqual('Test Category 1', rv.json[0]['display_name'])
+        self.assertEqual(0, rv.json[0]['display_order'])
+        self.assertEqual('Test Category 2', rv.json[1]['display_name'])
+        self.assertEqual(1, rv.json[1]['display_order'])
+        self.assertEqual('Test Category', rv.json[2]['display_name'])
+        self.assertEqual(2, rv.json[2]['display_order'])
+        self.assertEqual('Test Category 3', rv.json[3]['display_name'])
+        self.assertEqual(3, rv.json[3]['display_order'])

--- a/tests/workflow/test_workflow_spec_category_reorder.py
+++ b/tests/workflow/test_workflow_spec_category_reorder.py
@@ -1,0 +1,109 @@
+from tests.base_test import BaseTest
+
+from crc import session
+from crc.api.common import ApiError
+from crc.models.workflow import WorkflowSpecCategoryModel
+
+import json
+
+
+class TestWorkflowSpecCategoryReorder(BaseTest):
+
+    @staticmethod
+    def _load_test_categories():
+        category_model_1 = WorkflowSpecCategoryModel(
+            id=1,
+            name='test_category_1',
+            display_name='Test Category 1',
+            display_order=1
+        )
+        category_model_2 = WorkflowSpecCategoryModel(
+            id=2,
+            name='test_category_2',
+            display_name='Test Category 2',
+            display_order=2
+        )
+        category_model_3 = WorkflowSpecCategoryModel(
+            id=3,
+            name='test_category_3',
+            display_name='Test Category 3',
+            display_order=3
+        )
+        session.add(category_model_1)
+        session.add(category_model_2)
+        session.add(category_model_3)
+        session.commit()
+
+    def test_initial_order(self):
+        self.load_example_data()
+        self._load_test_categories()
+        initial_order = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+        self.assertEqual(0, initial_order[0].id)
+        self.assertEqual(1, initial_order[1].id)
+        self.assertEqual(2, initial_order[2].id)
+        self.assertEqual(3, initial_order[3].id)
+
+    def test_workflow_spec_category_reorder_up(self):
+        self.load_example_data()
+        self._load_test_categories()
+
+        # Move category 2 up
+        rv = self.app.put(f"/v1.0/workflow-specification-category/2/reorder?direction=up",
+                          headers=self.logged_in_headers())
+
+        # Make sure category 2 is in position 1 now
+        self.assertEqual(2, rv.json[1]['id'])
+
+        ordered = session.query(WorkflowSpecCategoryModel).\
+            order_by(WorkflowSpecCategoryModel.display_order).all()
+        self.assertEqual(2, ordered[1].id)
+
+    def test_workflow_spec_category_reorder_down(self):
+        self.load_example_data()
+        self._load_test_categories()
+
+        # Move category 2 down
+        rv = self.app.put(f"/v1.0/workflow-specification-category/2/reorder?direction=down",
+                          headers=self.logged_in_headers())
+
+        # Make sure category 2 is in position 3 now
+        self.assertEqual(2, rv.json[3]['id'])
+
+        ordered = session.query(WorkflowSpecCategoryModel). \
+            order_by(WorkflowSpecCategoryModel.display_order).all()
+        self.assertEqual(2, ordered[3].id)
+
+    def test_workflow_spec_category_reorder_bad_direction(self):
+        self.load_example_data()
+        self._load_test_categories()
+
+        rv = self.app.put(f"/v1.0/workflow-specification-category/2/reorder?direction=asdf",
+                          headers=self.logged_in_headers())
+        self.assertEqual('bad_direction', rv.json['code'])
+        self.assertEqual('The direction must be `up` or `down`.', rv.json['message'])
+
+    def test_workflow_spec_category_reorder_bad_category_id(self):
+        self.load_example_data()
+        self._load_test_categories()
+
+        # with self.assertRaises(ApiError):
+        rv = self.app.put(f"/v1.0/workflow-specification-category/10/reorder?direction=down",
+                          headers=self.logged_in_headers())
+        self.assertEqual('bad_category_id', rv.json['code'])
+        self.assertEqual('The category id 10 did not return a Workflow Spec Category. Make sure it is a valid ID.', rv.json['message'])
+
+    def test_workflow_spec_category_down_too_far(self):
+        self.load_example_data()
+        self._load_test_categories()
+        ordered = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+
+        # Try to move 3 down
+        rv = self.app.put(f"/v1.0/workflow-specification-category/3/reorder?direction=down",
+                          headers=self.logged_in_headers())
+        # Make sure we don't get an error
+        self.assert_success(rv)
+
+        # Make sure we get the original list back.
+        reordered = session.query(WorkflowSpecCategoryModel).order_by(WorkflowSpecCategoryModel.display_order).all()
+        self.assertEqual(ordered, reordered)
+

--- a/tests/workflow/test_workflow_spec_reorder.py
+++ b/tests/workflow/test_workflow_spec_reorder.py
@@ -1,0 +1,60 @@
+from tests.base_test import BaseTest
+
+from crc import session
+
+from crc.models.workflow import WorkflowSpecModel, WorkflowSpecModelSchema, WorkflowSpecCategoryModel
+
+
+import json
+
+
+class TestWorkflowSpecReorder(BaseTest):
+
+    def _load_sample_workflow_specs(self):
+        self.load_example_data()
+        workflow_spec_category = session.query(WorkflowSpecCategoryModel).first()
+        spec_model_1 = WorkflowSpecModel(id='test_spec_1', name='test_spec_1', display_name='Test Spec 1',
+                                         description='Test Spec 1 Description', category_id=workflow_spec_category.id,
+                                         standalone=False)
+        rv_1 = self.app.post('/v1.0/workflow-specification',
+                             headers=self.logged_in_headers(),
+                             content_type="application/json",
+                             data=json.dumps(WorkflowSpecModelSchema().dump(spec_model_1)))
+        spec_model_2 = WorkflowSpecModel(id='test_spec_2', name='test_spec_2', display_name='Test Spec 2',
+                                         description='Test Spec 2 Description', category_id=workflow_spec_category.id,
+                                         standalone=False)
+        rv_2 = self.app.post('/v1.0/workflow-specification',
+                             headers=self.logged_in_headers(),
+                             content_type="application/json",
+                             data=json.dumps(WorkflowSpecModelSchema().dump(spec_model_2)))
+        spec_model_3 = WorkflowSpecModel(id='test_spec_3', name='test_spec_3', display_name='Test Spec 3',
+                                         description='Test Spec 3 Description', category_id=workflow_spec_category.id,
+                                         standalone=False)
+        rv_3 = self.app.post('/v1.0/workflow-specification',
+                             headers=self.logged_in_headers(),
+                             content_type="application/json",
+                             data=json.dumps(WorkflowSpecModelSchema().dump(spec_model_3)))
+        return rv_1, rv_2, rv_3
+
+    def test_workflow_spec_reorder_no_direction(self):
+        rv_1, rv_2, rv_3 = self._load_sample_workflow_specs()
+        rv = self.app.put(f"/v1.0/workflow-specification/{rv_2.json['id']}/reorder?direction=asdf",
+                          headers=self.logged_in_headers())
+        self.assertEqual('400 BAD REQUEST', rv.status)
+        self.assertEqual("The direction must be `up` or `down`.", rv.json['message'])
+
+        print('test_workflow_spec_reorder_no_direction')
+
+    def test_workflow_spec_reorder_up(self):
+        rv_1, rv_2, rv_3 = self._load_sample_workflow_specs()
+
+        self.assertEqual(1, rv_1.json['display_order'])
+        self.assertEqual(2, rv_2.json['display_order'])
+        self.assertEqual(3, rv_3.json['display_order'])
+
+        rv = self.app.put(f"/v1.0/workflow-specification/{rv_2.json['id']}/reorder?direction=up",
+                          headers=self.logged_in_headers())
+        changed = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.id == 'test_spec_2').first()
+        self.assertEqual(1, changed.display_order)
+
+        print('test_workflow_spec_reorder')

--- a/tests/workflow/test_workflow_spec_reorder.py
+++ b/tests/workflow/test_workflow_spec_reorder.py
@@ -9,7 +9,6 @@ import json
 class TestWorkflowSpecReorder(BaseTest):
 
     def _load_sample_workflow_specs(self):
-        self.load_example_data()
         workflow_spec_category = session.query(WorkflowSpecCategoryModel).first()
         spec_model_1 = WorkflowSpecModel(id='test_spec_1', name='test_spec_1', display_name='Test Spec 1',
                                          description='Test Spec 1 Description', category_id=workflow_spec_category.id,
@@ -35,6 +34,7 @@ class TestWorkflowSpecReorder(BaseTest):
         return rv_1, rv_2, rv_3
 
     def test_load_sample_workflow_specs(self):
+        self.load_example_data()
         rv_1, rv_2, rv_3 = self._load_sample_workflow_specs()
         self.assertEqual(1, rv_1.json['display_order'])
         self.assertEqual('test_spec_1', rv_1.json['name'])
@@ -44,6 +44,7 @@ class TestWorkflowSpecReorder(BaseTest):
         self.assertEqual('test_spec_3', rv_3.json['name'])
 
     def test_workflow_spec_reorder_bad_direction(self):
+        self.load_example_data()
         self._load_sample_workflow_specs()
         rv = self.app.put(f"/v1.0/workflow-specification/test_spec_2/reorder?direction=asdf",
                           headers=self.logged_in_headers())
@@ -51,6 +52,7 @@ class TestWorkflowSpecReorder(BaseTest):
         self.assertEqual("The direction must be `up` or `down`.", rv.json['message'])
 
     def test_workflow_spec_reorder_bad_spec_id(self):
+        self.load_example_data()
         self._load_sample_workflow_specs()
         rv = self.app.put(f"/v1.0/workflow-specification/10/reorder?direction=up",
                           headers=self.logged_in_headers())
@@ -58,10 +60,14 @@ class TestWorkflowSpecReorder(BaseTest):
         self.assertEqual('The spec_id 10 did not return a specification. Please check that it is valid.', rv.json['message'])
 
     def test_workflow_spec_reorder_up(self):
+        self.load_example_data()
         self._load_sample_workflow_specs()
 
         # Check what order is in the DB
-        ordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+        ordered = session.query(WorkflowSpecModel).\
+            filter(WorkflowSpecModel.category_id == 0).\
+            order_by(WorkflowSpecModel.display_order).\
+            all()
         self.assertEqual('test_spec_2', ordered[2].id)
 
         # Move test_spec_2 up
@@ -73,15 +79,22 @@ class TestWorkflowSpecReorder(BaseTest):
         self.assertEqual('test_spec_2', rv.json[1]['id'])
 
         # Check what new order is in the DB
-        reordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+        reordered = session.query(WorkflowSpecModel).\
+            filter(WorkflowSpecModel.category_id == 0).\
+            order_by(WorkflowSpecModel.display_order).\
+            all()
         self.assertEqual('test_spec_2', reordered[1].id)
         print('test_workflow_spec_reorder_up')
 
     def test_workflow_spec_reorder_down(self):
+        self.load_example_data()
         self._load_sample_workflow_specs()
 
         # Check what order is in the DB
-        ordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+        ordered = session.query(WorkflowSpecModel).\
+            filter(WorkflowSpecModel.category_id == 0).\
+            order_by(WorkflowSpecModel.display_order).\
+            all()
         self.assertEqual('test_spec_2', ordered[2].id)
 
         # Move test_spec_2 down
@@ -97,6 +110,7 @@ class TestWorkflowSpecReorder(BaseTest):
         self.assertEqual('test_spec_2', reordered[3].id)
 
     def test_workflow_spec_reorder_down_bad(self):
+        self.load_example_data()
         self._load_sample_workflow_specs()
 
         ordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()

--- a/tests/workflow/test_workflow_spec_reorder.py
+++ b/tests/workflow/test_workflow_spec_reorder.py
@@ -36,25 +36,80 @@ class TestWorkflowSpecReorder(BaseTest):
                              data=json.dumps(WorkflowSpecModelSchema().dump(spec_model_3)))
         return rv_1, rv_2, rv_3
 
-    def test_workflow_spec_reorder_no_direction(self):
+    def test_load_sample_workflow_specs(self):
         rv_1, rv_2, rv_3 = self._load_sample_workflow_specs()
-        rv = self.app.put(f"/v1.0/workflow-specification/{rv_2.json['id']}/reorder?direction=asdf",
+        self.assertEqual(1, rv_1.json['display_order'])
+        self.assertEqual('test_spec_1', rv_1.json['name'])
+        self.assertEqual(2, rv_2.json['display_order'])
+        self.assertEqual('test_spec_2', rv_2.json['name'])
+        self.assertEqual(3, rv_3.json['display_order'])
+        self.assertEqual('test_spec_3', rv_3.json['name'])
+
+
+    def test_workflow_spec_reorder_no_direction(self):
+        self._load_sample_workflow_specs()
+        rv = self.app.put(f"/v1.0/workflow-specification/test_spec_2/reorder?direction=asdf",
                           headers=self.logged_in_headers())
         self.assertEqual('400 BAD REQUEST', rv.status)
         self.assertEqual("The direction must be `up` or `down`.", rv.json['message'])
 
-        print('test_workflow_spec_reorder_no_direction')
+    def test_workflow_spec_reorder_bad_spec_id(self):
+        self._load_sample_workflow_specs()
+        rv = self.app.put(f"/v1.0/workflow-specification/10/reorder?direction=up",
+                          headers=self.logged_in_headers())
+        self.assertEqual('bad_spec_id', rv.json['code'])
+        self.assertEqual('The spec_id 10 did not return a specification. Please check that it is valid.', rv.json['message'])
 
     def test_workflow_spec_reorder_up(self):
-        rv_1, rv_2, rv_3 = self._load_sample_workflow_specs()
+        self._load_sample_workflow_specs()
 
-        self.assertEqual(1, rv_1.json['display_order'])
-        self.assertEqual(2, rv_2.json['display_order'])
-        self.assertEqual(3, rv_3.json['display_order'])
+        # Check what order is in the DB
+        ordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+        self.assertEqual('test_spec_2', ordered[2].id)
 
-        rv = self.app.put(f"/v1.0/workflow-specification/{rv_2.json['id']}/reorder?direction=up",
+        # Move test_spec_2 up
+        rv = self.app.put(f"/v1.0/workflow-specification/test_spec_2/reorder?direction=up",
                           headers=self.logged_in_headers())
-        changed = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.id == 'test_spec_2').first()
-        self.assertEqual(1, changed.display_order)
 
-        print('test_workflow_spec_reorder')
+        # rv json contains the newly order list of specs
+        self.assertEqual(1, rv.json[1]['display_order'])
+        self.assertEqual('test_spec_2', rv.json[1]['id'])
+
+        # Check what new order is in the DB
+        reordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+        self.assertEqual('test_spec_2', reordered[1].id)
+        print('test_workflow_spec_reorder_up')
+
+    def test_workflow_spec_reorder_down(self):
+        self._load_sample_workflow_specs()
+
+        # Check what order is in the DB
+        ordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+        self.assertEqual('test_spec_2', ordered[2].id)
+
+        # Move test_spec_2 down
+        rv = self.app.put(f"/v1.0/workflow-specification/test_spec_2/reorder?direction=down",
+                          headers=self.logged_in_headers())
+
+        # rv json contains the newly order list of specs
+        self.assertEqual('test_spec_2', rv.json[3]['id'])
+        self.assertEqual(3, rv.json[3]['display_order'])
+
+        # Check what new order is in the DB
+        reordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+        self.assertEqual('test_spec_2', reordered[3].id)
+
+    def test_workflow_spec_reorder_down_bad(self):
+        self._load_sample_workflow_specs()
+
+        ordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+
+        # Try to move test_spec_3 down
+        rv = self.app.put(f"/v1.0/workflow-specification/test_spec_3/reorder?direction=down",
+                          headers=self.logged_in_headers())
+        # Make sure we don't get an error
+        self.assert_success(rv)
+
+        # Make sure we get the original list back.
+        reordered = session.query(WorkflowSpecModel).order_by(WorkflowSpecModel.display_order).all()
+        self.assertEqual(ordered, reordered)

--- a/tests/workflow/test_workflow_spec_reorder.py
+++ b/tests/workflow/test_workflow_spec_reorder.py
@@ -1,9 +1,7 @@
 from tests.base_test import BaseTest
 
 from crc import session
-
 from crc.models.workflow import WorkflowSpecModel, WorkflowSpecModelSchema, WorkflowSpecCategoryModel
-
 
 import json
 
@@ -45,8 +43,7 @@ class TestWorkflowSpecReorder(BaseTest):
         self.assertEqual(3, rv_3.json['display_order'])
         self.assertEqual('test_spec_3', rv_3.json['name'])
 
-
-    def test_workflow_spec_reorder_no_direction(self):
+    def test_workflow_spec_reorder_bad_direction(self):
         self._load_sample_workflow_specs()
         rv = self.app.put(f"/v1.0/workflow-specification/test_spec_2/reorder?direction=asdf",
                           headers=self.logged_in_headers())


### PR DESCRIPTION
We created 2 new API endpoints for reordering specs and categories
We cleaned up adding/deleting/updating to make sure we have good display_order
We no longer allow adding and deleting to set the display_order

Most of this is new code, however, there are a *bunch* of changes to crc.api.workflow

api.yml 
    - added two new endpoints 

crc.api.workfow 
    - added methods for the new endpoints
    - make sure we have good display_order when adding
    - cleanup display_order when deleting
    - make sure we don't change display_order when updating

crc.services.workflow_service
    - add helper methods for the new reorder endpoints
    - add methods to clean up display_orders for specs and categories

tests.workflow.test_workflow_spec_api
    - added tests for deleting categories
    - check display order after deleting specs and categories

tests.workflow.test_workflow_spec_category_reorder
    - new
    - tests for reordering

tests.workflow.test_workflow_spec_reorder
    - new
    - tests for reordering
