### PR TITLE
Added file_id to some error messages in api.file #449

### DIFF
--- a/crc/api/file.py
+++ b/crc/api/file.py
@@ -110,7 +110,7 @@ def update_file_data(file_id):
     file_model = session.query(FileModel).filter_by(id=file_id).with_for_update().first()
     file = connexion.request.files['file']
     if file_model is None:
-        raise ApiError('no_such_file', 'The file id you provided does not exist')
+        raise ApiError('no_such_file', f'The file id you provided ({file_id}) does not exist')
     file_model = FileService.update_file(file_model, file.stream.read(), file.content_type)
     return FileSchema().dump(to_file_api(file_model))
 
@@ -121,7 +121,7 @@ def get_file_data_by_hash(md5_hash):
 def get_file_data(file_id, version=None):
     file_data = FileService.get_file_data(file_id, version)
     if file_data is None:
-        raise ApiError('no_such_file', 'The file id you provided does not exist')
+        raise ApiError('no_such_file', f'The file id you provided ({file_id}) does not exist')
     return send_file(
         io.BytesIO(file_data.data),
         attachment_filename=file_data.file_model.name,
@@ -136,7 +136,7 @@ def get_file_data_link(file_id, auth_token, version=None):
         raise ApiError('not_authenticated', 'You need to include an authorization token in the URL with this')
     file_data = FileService.get_file_data(file_id, version)
     if file_data is None:
-        raise ApiError('no_such_file', 'The file id you provided does not exist')
+        raise ApiError('no_such_file', f'The file id you provided ({file_id}) does not exist')
     return send_file(
         io.BytesIO(file_data.data),
         attachment_filename=file_data.file_model.name,
@@ -150,7 +150,7 @@ def get_file_data_link(file_id, auth_token, version=None):
 def get_file_info(file_id):
     file_model = session.query(FileModel).filter_by(id=file_id).with_for_update().first()
     if file_model is None:
-        raise ApiError('no_such_file', 'The file id you provided does not exist', status_code=404)
+        raise ApiError('no_such_file', f'The file id you provided ({file_id}) does not exist', status_code=404)
     return FileSchema().dump(to_file_api(file_model))
 
 


### PR DESCRIPTION
Added file_id to some error messages in api.file, for ticket 449.
The ticket says this happened test the delete_task_data script, but I don't believe that script calls the API.
Not sure why the error happened, but we now send more info with the error message.