### PR TITLE
Study info mislabeled #464

### DIFF
--- a/crc/api/tools.py
+++ b/crc/api/tools.py
@@ -1,6 +1,8 @@
 import hashlib
 import io
 import json
+import inspect
+import os
 
 import connexion
 from SpiffWorkflow.bpmn.PythonScriptEngine import PythonScriptEngine
@@ -58,11 +60,17 @@ def list_scripts():
     scripts = Script.get_all_subclasses()
     script_meta = []
     for script_class in scripts:
-        script_meta.append(
-            {
-                "name": script_class.__name__,
-                "description": script_class().get_description()
-            })
+        file_path = inspect.getfile(script_class)
+        file_name = os.path.basename(file_path)
+        # This grabs the filename without the suffix,
+        # which is what configurators actually use in a script task.
+        handle = os.path.splitext(file_name)[0]
+        meta_data = {
+            "name": script_class.__name__,
+            "handle": handle,
+            "description": script_class().get_description()
+        }
+        script_meta.append(meta_data)
     return script_meta
 
 

--- a/crc/scripts/complete_template.py
+++ b/crc/scripts/complete_template.py
@@ -18,8 +18,7 @@ from crc.services.workflow_processor import WorkflowProcessor
 class CompleteTemplate(Script):
 
     def get_description(self):
-        return """        
-Using the Jinja template engine, takes data available in the current task, and uses it to populate 
+        return """Using the Jinja template engine, takes data available in the current task, and uses it to populate 
 a word document that contains Jinja markup.  Please see https://docxtpl.readthedocs.io/en/latest/ 
 for more information on exact syntax.
 Takes two arguments:

--- a/crc/scripts/email.py
+++ b/crc/scripts/email.py
@@ -18,8 +18,7 @@ class Email(Script):
        You can also specify cc, bcc, reply_to, and attachments"""
 
     def get_description(self):
-        return """
-Creates an email, using the provided `subject` and `recipients` arguments, which are required.
+        return """Creates an email, using the provided `subject` and `recipients` arguments, which are required.
 The `Element Documentation` field in the script task must contain markdown that becomes the body of the email message.
 
 You can also provide `cc`, `bcc`, `reply_to` and `attachments` arguments.  

--- a/crc/scripts/get_study_associate.py
+++ b/crc/scripts/get_study_associate.py
@@ -9,8 +9,7 @@ class GetStudyAssociate(Script):
 
 
     def get_description(self):
-        return """
-Returns how a single person is associated with a study and what access they need,
+        return """Returns how a single person is associated with a study and what access they need,
  or raises an error if the person is not associated with the study.
 example : get_study_associate('sbp3ey') => {'uid':'sbp3ey','role':'Unicorn Herder', 'send_email': False, 
 'access':True}

--- a/crc/scripts/get_study_associates.py
+++ b/crc/scripts/get_study_associates.py
@@ -13,8 +13,7 @@ class GetStudyAssociates(Script):
 
 
     def get_description(self):
-        return """
-Returns all people associated with the study - Will always return the study owner as assocated
+        return """Returns all people associated with the study - Will always return the study owner as assocated
 example : get_study_associates() => [{'uid':'sbp3ey','role':'Unicorn Herder', 'send_email': False, 'access':True}] 
 
 """

--- a/crc/scripts/get_zipped_files.py
+++ b/crc/scripts/get_zipped_files.py
@@ -14,7 +14,7 @@ class GetZippedFiles(Script):
     """This script creates a zip document from a list of file ids"""
 
     def get_description(self):
-        """Creates a zip file from a list of file_ids.
+        return """Creates a zip file from a list of file_ids.
            This is meant to use as an attachment to an email message"""
 
     def do_task_validate_only(self, task, study_id, workflow_id, *args, **kwargs):

--- a/crc/scripts/ldap.py
+++ b/crc/scripts/ldap.py
@@ -15,8 +15,7 @@ class Ldap(Script):
     If no user id is specified, returns information about the current user."""
 
     def get_description(self):
-        return """
-Attempts to create a dictionary with person details, using the
+        return """Attempts to create a dictionary with person details, using the
 provided argument (a UID) and look it up through LDAP.  If no UID is
 provided, then returns information about the current user.
 

--- a/crc/scripts/study_info.py
+++ b/crc/scripts/study_info.py
@@ -119,8 +119,7 @@ class StudyInfo(Script):
         return json.dumps(self.example_data['StudyInfo'][key], indent=2, separators=(',', ': '))
 
     def get_description(self):
-        return """
-StudyInfo [TYPE], where TYPE is one of 'info', 'investigators', 'details', or 'documents'.
+        return """study_info(TYPE), where TYPE is one of 'info', 'investigators', 'details', or 'documents'.
 
 Adds details about the current study to the Task Data.  The type of information required should be 
 provided as an argument.  The following arguments are available:

--- a/crc/scripts/update_study.py
+++ b/crc/scripts/update_study.py
@@ -18,8 +18,7 @@ class UpdateStudy(Script):
                              "update_study task, in the form [study_field]=[value]",
 
     def get_description(self):
-        return """
-Allows you to set specific attributes on the Study model by mapping them to 
+        return """Allows you to set specific attributes on the Study model by mapping them to 
 values in the task data.  Should be called with the value to set (either title, short_title, or pi)
 
 Example:

--- a/crc/scripts/update_study_associate.py
+++ b/crc/scripts/update_study_associate.py
@@ -12,8 +12,7 @@ class UpdateStudyAssociates(Script):
 
 
     def get_description(self):
-        return """
-Allows you to associate other users with a study - only 'uid' is a required keyword argument
+        return """Allows you to associate other users with a study - only 'uid' is a required keyword argument
 
 
 An empty list will delete the existing Associated list (except owner)

--- a/crc/scripts/update_study_associates.py
+++ b/crc/scripts/update_study_associates.py
@@ -10,8 +10,7 @@ class UpdateStudyAssociates(Script):
                              "'access':'boolean'} "
 
     def get_description(self):
-        return """
-Allows you to associate other users with a study - only 'uid' is required in the 
+        return """Allows you to associate other users with a study - only 'uid' is required in the 
 incoming dictionary, but will be useless without other information - all values will default to 
 false or blank
 

--- a/tests/test_tools_api.py
+++ b/tests/test_tools_api.py
@@ -36,6 +36,7 @@ class TestToolsApi(BaseTest):
         scripts = json.loads(rv.get_data(as_text=True))
         self.assertTrue(len(scripts) > 1)
         self.assertIsNotNone(scripts[0]['name'])
+        self.assertIsNotNone(scripts[0]['handle'])
         self.assertIsNotNone(scripts[0]['description'])
 
     def test_eval_hide_expression(self):


### PR DESCRIPTION
Add an entry in the tools/list_scripts API endpoint that displays the filename, which is what configurators actually call in a script task.
Cleaned up some of the text in descriptions that is returned by the same endpoint.