### PR TITLE
Bug/246 user ldap refactor

### DIFF
--- a/crc/api/user.py
+++ b/crc/api/user.py
@@ -228,20 +228,17 @@ def _handle_login(user_info: LdapModel, redirect_url=None):
         return auth_token
 
 
-def _upsert_user(user_info):
-    user = session.query(UserModel).filter(UserModel.uid == user_info.uid).first()
+def _upsert_user(ldap_info):
+    user = session.query(UserModel).filter(UserModel.uid == ldap_info.uid).first()
 
     if user is None:
         # Add new user
         user = UserModel()
     else:
-        user = session.query(UserModel).filter(UserModel.uid == user_info.uid).with_for_update().first()
+        user = session.query(UserModel).filter(UserModel.uid == ldap_info.uid).with_for_update().first()
 
-    user.uid = user_info.uid
-    user.display_name = user_info.display_name
-    user.email_address = user_info.email_address
-    user.affiliation = user_info.affiliation
-    user.title = user_info.title
+    user.uid = ldap_info.uid
+    user.ldap_info = ldap_info
 
     session.add(user)
     session.commit()

--- a/crc/models/study.py
+++ b/crc/models/study.py
@@ -10,6 +10,7 @@ from sqlalchemy import func
 from crc import db, ma
 from crc.api.common import ApiErrorSchema, ApiError
 from crc.models.file import FileModel, SimpleFileSchema, FileSchema
+from crc.models.ldap import LdapModel, LdapSchema
 from crc.models.protocol_builder import ProtocolBuilderStatus, ProtocolBuilderStudy
 from crc.models.workflow import WorkflowSpecCategoryModel, WorkflowState, WorkflowStatus, WorkflowSpecModel, \
     WorkflowModel
@@ -76,13 +77,17 @@ class StudyAssociated(db.Model):
     role = db.Column(db.String, nullable=True)
     send_email = db.Column(db.Boolean, nullable=True)
     access = db.Column(db.Boolean, nullable=True)
+    ldap_info = db.relationship(LdapModel)
 
 
 class StudyAssociatedSchema(ma.Schema):
     class Meta:
-        fields=['uid', 'role', 'send_email', 'access']
+        fields=['uid', 'role', 'send_email', 'access', 'ldap_info']
         model = StudyAssociated
         unknown = INCLUDE
+    ldap_info = fields.Nested(LdapSchema, dump_only=True)
+
+
 
 class StudyEvent(db.Model):
     __tablename__ = 'study_event'

--- a/crc/models/user.py
+++ b/crc/models/user.py
@@ -6,21 +6,14 @@ from marshmallow_sqlalchemy import SQLAlchemyAutoSchema
 
 from crc import db, app
 from crc.api.common import ApiError
+from crc.models.ldap import LdapSchema
 
 
 class UserModel(db.Model):
     __tablename__ = 'user'
     id = db.Column(db.Integer, primary_key=True)
-    uid = db.Column(db.String, unique=True)
-    email_address = db.Column(db.String)
-    display_name = db.Column(db.String)
-    affiliation = db.Column(db.String, nullable=True)
-    eppn = db.Column(db.String, nullable=True)
-    first_name = db.Column(db.String, nullable=True)
-    last_name = db.Column(db.String, nullable=True)
-    title = db.Column(db.String, nullable=True)
-
-    # TODO: Add Department and School
+    uid = db.Column(db.String, db.ForeignKey('ldap_model.uid'), unique=True)
+    ldap_info = db.relationship("LdapModel")
 
     def is_admin(self):
         # Currently admin abilities are set in the configuration, but this
@@ -65,7 +58,9 @@ class UserModelSchema(SQLAlchemyAutoSchema):
         model = UserModel
         load_instance = True
         include_relationships = True
+    uid = fields.String()
     is_admin = fields.Method('get_is_admin', dump_only=True)
+    ldap_info = fields.Nested(LdapSchema)
 
     def get_is_admin(self, obj):
         return obj.is_admin()

--- a/crc/services/study_service.py
+++ b/crc/services/study_service.py
@@ -143,7 +143,9 @@ class StudyService(object):
             raise ApiError('study_not_found', 'No study found with id = %d' % study_id)
 
         people = db.session.query(StudyAssociated).filter(StudyAssociated.study_id == study_id).all()
-        owner = StudyAssociated(uid=study.user_uid, role='owner', send_email=True, access=True)
+        ldap_info = LdapService.user_info(study.user_uid)
+        owner = StudyAssociated(uid=study.user_uid, role='owner', send_email=True, access=True,
+                                ldap_info=ldap_info)
         people.append(owner)
         return people
 

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -27,6 +27,7 @@ from crc.api.common import ApiError
 from crc.models.api_models import Task, MultiInstanceType, WorkflowApi
 from crc.models.data_store import DataStoreModel
 from crc.models.file import LookupDataModel, FileModel, File, FileSchema
+from crc.models.ldap import LdapModel
 from crc.models.study import StudyModel
 from crc.models.task_event import TaskEventModel
 from crc.models.user import UserModel, UserModelSchema
@@ -69,6 +70,7 @@ class WorkflowService(object):
         if not user:
             user = db.session.query(UserModel).filter_by(uid="test").first()
         if not user:
+            db.session.add(LdapModel(uid="test"))
             db.session.add(UserModel(uid="test"))
             db.session.commit()
             user = db.session.query(UserModel).filter_by(uid="test").first()
@@ -93,6 +95,9 @@ class WorkflowService(object):
         for study in db.session.query(StudyModel).filter(StudyModel.user_uid == "test"):
             StudyService.delete_study(study.id)
         user = db.session.query(UserModel).filter_by(uid="test").first()
+        ldap = db.session.query(LdapModel).filter_by(uid="test").first()
+        if ldap:
+            db.session.delete(ldap)
         if user:
             db.session.delete(user)
         db.session.commit()

--- a/example_data.py
+++ b/example_data.py
@@ -335,10 +335,10 @@ class ExampleDataLoader:
         file.close()
 
     def load_default_user(self):
-        user = UserModel(uid="dhf8r", email_address="dhf8r@virginia.edu", display_name="Development User")
         ldap_info = LdapModel(uid="dhf8r", email_address="dhf8r@virginia.edu", display_name="Development User")
-        db.session.add(user)
+        user = UserModel(uid="dhf8r", ldap_info=ldap_info)
         db.session.add(ldap_info)
+        db.session.add(user)
         db.session.commit()
 
 def ldap(): return "x";

--- a/tests/data/file_data_store/file_data_store.bpmn
+++ b/tests/data/file_data_store/file_data_store.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1j7idla" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.7.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_1j7idla" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.10.0">
   <bpmn:process id="Process_18biih5" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>SequenceFlow_1pnq3kg</bpmn:outgoing>
@@ -16,7 +16,7 @@
       <bpmn:outgoing>Flow_0z7kamo</bpmn:outgoing>
       <bpmn:script>filelist = list(documents.keys())
 
-fileid = documents['UVACompl_PRCAppr'].files[0]['file_id']
+fileid = documents['UVACompl_PRCAppr'].files[0]['id']
 
 fileurl = documents['UVACompl_PRCAppr'].files[0]['url']
 
@@ -43,6 +43,22 @@ file_data_set(file_id=fileid,key='test',value='me')</bpmn:script>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_18biih5">
+      <bpmndi:BPMNEdge id="Flow_02bgcrp_di" bpmnElement="Flow_02bgcrp">
+        <di:waypoint x="860" y="117" />
+        <di:waypoint x="962" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_15mmymi_di" bpmnElement="Flow_15mmymi">
+        <di:waypoint x="690" y="117" />
+        <di:waypoint x="760" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_0z7kamo_di" bpmnElement="Flow_0z7kamo">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="590" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_1xqewuk_di" bpmnElement="Flow_1xqewuk">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="SequenceFlow_1pnq3kg_di" bpmnElement="SequenceFlow_1pnq3kg">
         <di:waypoint x="215" y="117" />
         <di:waypoint x="270" y="117" />
@@ -53,34 +69,18 @@ file_data_set(file_id=fileid,key='test',value='me')</bpmn:script>
       <bpmndi:BPMNShape id="Activity_01ekdl8_di" bpmnElement="Task_Has_Bananas">
         <dc:Bounds x="270" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_1xqewuk_di" bpmnElement="Flow_1xqewuk">
-        <di:waypoint x="370" y="117" />
-        <di:waypoint x="430" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0g5namy_di" bpmnElement="Activity_0yikdu7">
         <dc:Bounds x="430" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_1pdyoyv_di" bpmnElement="Event_1pdyoyv">
         <dc:Bounds x="962" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_0z7kamo_di" bpmnElement="Flow_0z7kamo">
-        <di:waypoint x="530" y="117" />
-        <di:waypoint x="590" y="117" />
-      </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_15mmymi_di" bpmnElement="Flow_15mmymi">
-        <di:waypoint x="690" y="117" />
-        <di:waypoint x="760" y="117" />
-      </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="Activity_0ma7ela_di" bpmnElement="Activity_19x6e2e">
         <dc:Bounds x="590" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_0oaeqxs_di" bpmnElement="Activity_0oaeqxs">
         <dc:Bounds x="760" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNEdge id="Flow_02bgcrp_di" bpmnElement="Flow_02bgcrp">
-        <di:waypoint x="860" y="117" />
-        <di:waypoint x="962" y="117" />
-      </bpmndi:BPMNEdge>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>
 </bpmn:definitions>

--- a/tests/study/test_study_associate_script.py
+++ b/tests/study/test_study_associate_script.py
@@ -8,6 +8,8 @@ from crc.services.user_service import UserService
 
 from crc import session, app
 from crc.models.study import StudyModel
+from crc.models.ldap import LdapSchema
+from crc.services.ldap_service import LdapService
 from crc.models.user import UserModel
 from crc.api.study import user_studies
 from crc.services.study_service import StudyService
@@ -53,17 +55,20 @@ class TestSudySponsorsScript(BaseTest):
         self.assertIn('sponsors', data)
         self.assertIn('out', data)
         print(data['out'])
-        self.assertDictEqual({'uid': 'dhf8r', 'role': 'owner', 'send_email': True, 'access': True},
+        dhf8r_info = LdapSchema().dump(LdapService.user_info('dhf8r'))
+        lb3dp_info = LdapSchema().dump(LdapService.user_info('lb3dp'))
+
+        self.assertDictEqual({'uid': 'dhf8r', 'role': 'owner', 'send_email': True, 'access': True, 'ldap_info': dhf8r_info},
                              data['out'][1])
-        self.assertDictEqual({'uid': 'lb3dp', 'role': 'SuperDude', 'send_email': False, 'access': True},
+        self.assertDictEqual({'uid': 'lb3dp', 'role': 'SuperDude', 'send_email': False, 'access': True, 'ldap_info': lb3dp_info},
                              data['out'][0])
-        self.assertDictEqual({'uid': 'lb3dp', 'role': 'SuperDude', 'send_email': False, 'access': True},
+        self.assertDictEqual({'uid': 'lb3dp', 'role': 'SuperDude', 'send_email': False, 'access': True, 'ldap_info': lb3dp_info},
                              data['out2'])
-        self.assertDictEqual({'uid': 'dhf8r', 'role': 'owner', 'send_email': True, 'access': True},
+        self.assertDictEqual({'uid': 'dhf8r', 'role': 'owner', 'send_email': True, 'access': True, 'ldap_info': dhf8r_info},
                              data['out3'][1])
-        self.assertDictEqual({'uid': 'lb3dp', 'role': 'SuperGal', 'send_email': False, 'access': True},
+        self.assertDictEqual({'uid': 'lb3dp', 'role': 'SuperGal', 'send_email': False, 'access': True, 'ldap_info': lb3dp_info},
                              data['out3'][0])
-        self.assertDictEqual({'uid': 'lb3dp', 'role': 'SuperGal', 'send_email': False, 'access': True},
+        self.assertDictEqual({'uid': 'lb3dp', 'role': 'SuperGal', 'send_email': False, 'access': True, 'ldap_info': lb3dp_info},
                              data['out4'])
         self.assertEqual(3, len(data['sponsors']))
 

--- a/tests/study/test_study_service.py
+++ b/tests/study/test_study_service.py
@@ -156,7 +156,7 @@ class TestStudyService(BaseTest):
         self.assertEqual("not_started", docs["UVACompl_PRCAppr"]['status'])
         self.assertEqual(1, docs["UVACompl_PRCAppr"]['count'])
         self.assertIsNotNone(docs["UVACompl_PRCAppr"]['files'][0])
-        self.assertIsNotNone(docs["UVACompl_PRCAppr"]['files'][0]['file_id'])
+        self.assertIsNotNone(docs["UVACompl_PRCAppr"]['files'][0]['id'])
         self.assertEqual(workflow.id, docs["UVACompl_PRCAppr"]['files'][0]['workflow_id'])
 
     def test_get_all_studies(self):

--- a/tests/study/test_study_service.py
+++ b/tests/study/test_study_service.py
@@ -5,15 +5,14 @@ from unittest.mock import patch
 from tests.base_test import BaseTest
 
 from crc import db, app
-from crc.models.protocol_builder import ProtocolBuilderStatus
-from crc.models.study import StudyModel, StudyStatus
+from crc.models.study import StudyModel, StudyStatus, StudyAssociatedSchema
 from crc.models.user import UserModel
 from crc.models.workflow import WorkflowModel, WorkflowStatus, \
     WorkflowSpecCategoryModel
 from crc.services.file_service import FileService
+from crc.services.ldap_service import LdapService
 from crc.services.study_service import StudyService
 from crc.services.workflow_processor import WorkflowProcessor
-from example_data import ExampleDataLoader
 
 
 class TestStudyService(BaseTest):
@@ -33,7 +32,8 @@ class TestStudyService(BaseTest):
         self.load_test_spec("top_level_workflow", master_spec=True, category_id=cat.id)
         user = db.session.query(UserModel).filter(UserModel.uid == "dhf8r").first()
         if not user:
-            user = UserModel(uid="dhf8r", email_address="whatever@stuff.com", display_name="Stayathome Smellalots")
+            ldap = LdapService.user_info('dhf8r')
+            user = UserModel(uid="dhf8r", ldap_info=ldap)
             db.session.add(user)
             db.session.commit()
         else:
@@ -257,3 +257,12 @@ class TestStudyService(BaseTest):
         studies = StudyService().get_studies_for_user(user)
         # study_details has an invalid REVIEW_TYPE, so we should get 0 studies back
         self.assertEqual(0, len(studies))
+
+    def test_study_associates(self):
+        user = self.create_user_with_study_and_workflow()
+        study = db.session.query(StudyModel).first()
+        associates = StudyService.get_study_associates(study.id)
+        self.assertEquals(1, len(associates))
+        assoc_json = StudyAssociatedSchema(many=True).dump(associates)
+        print(assoc_json)
+        self.assertEquals("Dan", assoc_json[0]['ldap_info']['given_name'])

--- a/tests/test_study_info_script.py
+++ b/tests/test_study_info_script.py
@@ -1,3 +1,6 @@
+import io
+import json
+
 from tests.base_test import BaseTest
 from crc.scripts.study_info import StudyInfo
 from crc import app
@@ -13,15 +16,15 @@ class TestStudyInfoScript(BaseTest):
     def do_work(self, info_type):
         app.config['PB_ENABLED'] = True
         self.load_example_data()
-        workflow = self.create_workflow('study_info_script')
-        workflow_api = self.get_workflow_api(workflow)
+        self.workflow = self.create_workflow('study_info_script')
+        self.workflow_api = self.get_workflow_api(self.workflow)
         # grab study_info directly from script
-        study_info = StudyInfo().do_task(workflow_api.study_id, workflow.study.id, workflow.id, info_type)
+        study_info = StudyInfo().do_task(self.workflow_api.study_id, self.workflow.study.id, self.workflow.id, info_type)
 
         # grab study info through a workflow
-        first_task = workflow_api.next_task
-        self.complete_form(workflow, first_task, {'which': info_type})
-        workflow_api = self.get_workflow_api(workflow)
+        first_task = self.workflow_api.next_task
+        self.complete_form(self.workflow, first_task, {'which': info_type})
+        workflow_api = self.get_workflow_api(self.workflow)
         second_task = workflow_api.next_task
 
         return study_info, second_task
@@ -62,9 +65,29 @@ class TestStudyInfoScript(BaseTest):
         self.assertEqual(response['IND_2'], second_task.data['info']['IND_2'])
         self.assertEqual(response['IND_3'], second_task.data['info']['IND_3'])
 
-    # def test_info_script_documents(self):
-    #     study_info, second_task = self.do_work(info_type='documents')
-    #     self.assertEqual(study_info, second_task.data['info'])
+    def test_info_script_documents(self):
+        study_info, second_task = self.do_work(info_type='documents')
+        self.assertEqual(study_info, second_task.data['info'])
+        self.assertEqual(0, len(study_info['Grant_App']['files']), "Grant_App has not files yet.")
+        # Add a grant app file
+        data = {'file': (io.BytesIO(b"abcdef"), 'random_fact.svg')}
+        rv = self.app.post('/v1.0/file?study_id=%i&workflow_id=%s&task_spec_name=%s&form_field_key=%s' %
+                           (self.workflow.study_id, self.workflow.id, second_task.name, 'Grant_App'), data=data, follow_redirects=True,
+                           content_type='multipart/form-data', headers=self.logged_in_headers())
+        self.assert_success(rv)
+        file_data = json.loads(rv.get_data(as_text=True))
+
+        # Now get the study info again.
+        study_info = StudyInfo().do_task(self.workflow_api.study_id, self.workflow.study.id, self.workflow.id,
+                                         'documents')
+        # The data should contain a file.
+        self.assertEqual(1, len(study_info['Grant_App']['files']), "Grant_App has exactly one file.")
+
+        # This file data returned should be the same as what we get back about the file when we uploaded it,
+        # but the details on the document should be removed, because that would be recursive.
+        del file_data['document']
+        self.assertEqual(file_data, study_info['Grant_App']['files'][0])
+
 
     @patch('crc.services.protocol_builder.requests.get')
     def test_info_script_sponsors(self, mock_get):


### PR DESCRIPTION
This has companion changes in the FrontEnd and BPMN as well.  Previously we had duplicated data in the User Table with data in the LDAP table.  And this duplication percolated up through the API and into both front end applications.  Fixing it so we we store this information as it comes from LDAP, and pass that data structure up through consistently.  