### PR TITLE
Top level validation #460

### DIFF
--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -132,6 +132,13 @@ class WorkflowService(object):
           spec, only completing the required fields, rather than everything.
           """
 
+        # Get workflow state dictionary, make sure workflow is not disabled.
+        if validate_study_id is not None:
+            study_model = session.query(StudyModel).filter(StudyModel.id == validate_study_id).first()
+            spec_model = session.query(WorkflowSpecModel).filter(WorkflowSpecModel.id == spec_id).first()
+            status = StudyService._get_study_status(study_model)
+            if status[spec_model.name]['status'] == 'disabled':
+                raise ApiError(code='disabled_workflow', message=f"This workflow is disabled. {status[spec_model.name]['message']}")
         workflow_model = WorkflowService.make_test_workflow(spec_id, validate_study_id)
         try:
             processor = WorkflowProcessor(workflow_model, validate_only=True)

--- a/tests/data/pb_responses/_get_study_status.json
+++ b/tests/data/pb_responses/_get_study_status.json
@@ -1,0 +1,5 @@
+[{
+  "core_info": {"status": "required", "message": "This workflow is always required and recommended that it is completed after your Protocol Builder entries are done and the Personnel workflow completed"},
+  "protocol": {"status": "required", "message": "required"},
+  "data_security_plan": {"status": "disabled", "message": "This is my mocked disable message."}
+}]


### PR DESCRIPTION
Add master workflow into the validation process.
If a workflow spec has been disabled by the master workflow, raise an ApiError with the message returned from the master workflow.