### PR TITLE
Ids approval validation #478

### DIFF
--- a/crc/api.yml
+++ b/crc/api.yml
@@ -145,6 +145,7 @@ paths:
           description: The remote endpoint
           schema:
             type: string
+            example: https://testing.crconnect.uvadcos.io/api
       tags:
         - Workflow Sync API
       responses:

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -428,16 +428,17 @@ class WorkflowService(object):
         the rest are pretty easy."""
         has_lookup = WorkflowService.has_lookup(field)
 
+        enum_value = None
         if field.type == "enum" and not has_lookup:
             # If it's a normal enum field with no lookup,
             # return a random option.
             if len(field.options) > 0:
                 random_choice = random.choice(field.options)
                 if isinstance(random_choice, dict):
-                    return {'value': random_choice['id'], 'label': random_choice['name'], 'data': random_choice['data']}
+                    enum_value = {'value': random_choice['id'], 'label': random_choice['name'], 'data': random_choice['data']}
                 else:
                     # fixme: why it is sometimes an EnumFormFieldOption, and other times not?
-                    return {'value': random_choice.id, 'label': random_choice.name}
+                    enum_value = {'value': random_choice.id, 'label': random_choice.name}
             else:
                 raise ApiError.from_task("invalid_enum", "You specified an enumeration field (%s),"
                                                          " with no options" % field.id, task)
@@ -446,19 +447,24 @@ class WorkflowService(object):
             # from the lookup model
             lookup_model = LookupService.get_lookup_model(task, field)
             if field.has_property(Task.FIELD_PROP_LDAP_LOOKUP):  # All ldap records get the same person.
-                return WorkflowService._random_ldap_record()
+                enum_value = WorkflowService._random_ldap_record()
             elif lookup_model:
                 data = db.session.query(LookupDataModel).filter(
                     LookupDataModel.lookup_file_model == lookup_model).limit(10).all()
                 options = [{"value": d.value, "label": d.label, "data": d.data} for d in data]
                 if len(options) > 0:
-                    return random.choice(options)
+                    enum_value = random.choice(options)
                 else:
                     raise ApiError.from_task("invalid enum", "You specified an enumeration field (%s),"
                                                              " with no options" % field.id, task)
             else:
                 raise ApiError.from_task("unknown_lookup_option", "The settings for this auto complete field "
                                                                  "are incorrect: %s " % field.id, task)
+        if enum_value is not None and field.has_property(Task.FIELD_PROP_ENUM_TYPE):
+            if field.get_property(Task.FIELD_PROP_ENUM_TYPE) == 'checkbox':
+                return [enum_value]
+            else:
+                return enum_value
         elif field.type == "long":
             return random.randint(1, 1000)
         elif field.type == 'boolean':

--- a/tests/data/enum_checkbox/enum_checkbox.bpmn
+++ b/tests/data/enum_checkbox/enum_checkbox.bpmn
@@ -25,7 +25,9 @@
     <bpmn:sequenceFlow id="Flow_07pr9lr" sourceRef="Activity_GetData" targetRef="Activity_DisplayData" />
     <bpmn:manualTask id="Activity_DisplayData" name="Display Data">
       <bpmn:documentation># Enum data
-{{ some_field }}</bpmn:documentation>
+{% for i in range(some_field | length) %}
+    {{ some_field[i] }}
+{% endfor %}</bpmn:documentation>
       <bpmn:incoming>Flow_07pr9lr</bpmn:incoming>
       <bpmn:outgoing>Flow_13oillk</bpmn:outgoing>
     </bpmn:manualTask>
@@ -38,10 +40,10 @@
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0ubt44i">
       <bpmndi:BPMNEdge id="Flow_1ui50vr_di" bpmnElement="Flow_1ui50vr">
         <di:waypoint x="215" y="117" />
-        <di:waypoint x="270" y="117" />
+        <di:waypoint x="271" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_07pr9lr_di" bpmnElement="Flow_07pr9lr">
-        <di:waypoint x="370" y="117" />
+        <di:waypoint x="371" y="117" />
         <di:waypoint x="430" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_13oillk_di" bpmnElement="Flow_13oillk">
@@ -51,14 +53,14 @@
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
         <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0krkqig_di" bpmnElement="Activity_GetData">
-        <dc:Bounds x="270" y="77" width="100" height="80" />
-      </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Activity_1aq717a_di" bpmnElement="Activity_DisplayData">
         <dc:Bounds x="430" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_0nm59tf_di" bpmnElement="Event_0nm59tf">
         <dc:Bounds x="592" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0krkqig_di" bpmnElement="Activity_GetData">
+        <dc:Bounds x="271" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/tests/data/enum_checkbox/enum_checkbox.bpmn
+++ b/tests/data/enum_checkbox/enum_checkbox.bpmn
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0vabmzb" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="Process_0ubt44i" isExecutable="true">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_1ui50vr</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_1ui50vr" sourceRef="StartEvent_1" targetRef="Activity_GetData" />
+    <bpmn:userTask id="Activity_GetData" name="Get Data" camunda:formKey="DataForm">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="some_field" label="Select" type="enum">
+            <camunda:properties>
+              <camunda:property id="enum_type" value="checkbox" />
+            </camunda:properties>
+            <camunda:value id="value_1" name="value_1" />
+            <camunda:value id="value_2" name="value_2" />
+            <camunda:value id="value_3" name="value_3" />
+            <camunda:value id="value_4" name="value_4" />
+          </camunda:formField>
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1ui50vr</bpmn:incoming>
+      <bpmn:outgoing>Flow_07pr9lr</bpmn:outgoing>
+    </bpmn:userTask>
+    <bpmn:sequenceFlow id="Flow_07pr9lr" sourceRef="Activity_GetData" targetRef="Activity_DisplayData" />
+    <bpmn:manualTask id="Activity_DisplayData" name="Display Data">
+      <bpmn:documentation># Enum data
+{{ some_field }}</bpmn:documentation>
+      <bpmn:incoming>Flow_07pr9lr</bpmn:incoming>
+      <bpmn:outgoing>Flow_13oillk</bpmn:outgoing>
+    </bpmn:manualTask>
+    <bpmn:endEvent id="Event_0nm59tf">
+      <bpmn:incoming>Flow_13oillk</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_13oillk" sourceRef="Activity_DisplayData" targetRef="Event_0nm59tf" />
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_0ubt44i">
+      <bpmndi:BPMNEdge id="Flow_1ui50vr_di" bpmnElement="Flow_1ui50vr">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_07pr9lr_di" bpmnElement="Flow_07pr9lr">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="430" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_13oillk_di" bpmnElement="Flow_13oillk">
+        <di:waypoint x="530" y="117" />
+        <di:waypoint x="592" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0krkqig_di" bpmnElement="Activity_GetData">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_1aq717a_di" bpmnElement="Activity_DisplayData">
+        <dc:Bounds x="430" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_0nm59tf_di" bpmnElement="Event_0nm59tf">
+        <dc:Bounds x="592" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/workflow/test_workflow_enum_checkbox.py
+++ b/tests/workflow/test_workflow_enum_checkbox.py
@@ -1,0 +1,21 @@
+from tests.base_test import BaseTest
+
+
+class TestEnumCheckbox(BaseTest):
+
+    def test_enum_checkbox_validation(self):
+        spec_model = self.load_test_spec('enum_checkbox')
+        rv = self.app.get('/v1.0/workflow-specification/%s/validate' % spec_model.id, headers=self.logged_in_headers())
+        self.assertEqual([], rv.json)
+
+    def test_enum_checkbox(self):
+        workflow = self.create_workflow('enum_checkbox')
+        workflow_api = self.get_workflow_api(workflow)
+        task = workflow_api.next_task
+        data_values = [{'value': 'value_1', 'label': 'value_1'}, {'value': 'value_3', 'label': 'value_3'}]
+
+        self.complete_form(workflow, task, {'some_field': data_values})
+        workflow_api = self.get_workflow_api(workflow)
+        task = workflow_api.next_task
+
+        self.assertEqual("# Enum data\n[{'value': 'value_1', 'label': 'value_1'}, {'value': 'value_3', 'label': 'value_3'}]", task.documentation)

--- a/tests/workflow/test_workflow_enum_checkbox.py
+++ b/tests/workflow/test_workflow_enum_checkbox.py
@@ -18,4 +18,5 @@ class TestEnumCheckbox(BaseTest):
         workflow_api = self.get_workflow_api(workflow)
         task = workflow_api.next_task
 
-        self.assertEqual("# Enum data\n[{'value': 'value_1', 'label': 'value_1'}, {'value': 'value_3', 'label': 'value_3'}]", task.documentation)
+        self.assertIn("{'value': 'value_1', 'label': 'value_1'}", task.documentation)
+        self.assertIn("{'value': 'value_3', 'label': 'value_3'}", task.documentation)


### PR DESCRIPTION
Validation didn't work for checkbox enums.
Checkbox enums return a list of dictionaries.
Our validation only returned a dictionary.
We now check if it's a checkbox enum in `get_random_data_for_field`, and wrap the value in a list when appropriate.

Also, I snuck `https://testing.crconnect.uvadcos.io/api` into the example field for the sync API call so we don't have to type it in every time.