### PR TITLE
one solution for the Parallel nav order problem

### DIFF
--- a/crc/services/workflow_processor.py
+++ b/crc/services/workflow_processor.py
@@ -412,7 +412,7 @@ class WorkflowProcessor(object):
                 if task._is_descendant_of(last_user_task):
                     return task
             for task in ready_tasks:
-                if self.bpmn_workflow.last_task and task.parent == self.bpmn_workflow.last_task.parent:
+                if self.bpmn_workflow.last_task and task.parent == last_user_task.parent:
                     return task
 
             return ready_tasks[0]


### PR DESCRIPTION
Here is what this does. 

To pick the next task, we first get a list of ready tasks. Then, we get a list of all completed _user_ tasks (Not gateways and other stuff, just the rounded box things). 

-If we haven't done any tasks yet, pick the first ready task. 
-If we have done a task, take the last task we did and find its child. 
-If the last task doesn't have any children, pick the next ready task.