### PR TITLE
Fixes validation for #518

### DIFF
--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -363,6 +363,10 @@ class WorkflowService(object):
     def evaluate_property(property_name, field, task):
         expression = field.get_property(property_name)
         data = task.data
+        # If there's a field key with no initial value, give it one (None)
+        for field in task.task_spec.form.fields:
+            if field.id not in data:
+                data[field.id] = None
         if field.has_property(Task.FIELD_PROP_REPEAT):
             # Then you must evaluate the expression based on the data within the group, if that data exists.
             # There may not be data available in the group, if no groups where added

--- a/tests/workflow/test_workflow_value_expression.py
+++ b/tests/workflow/test_workflow_value_expression.py
@@ -3,6 +3,7 @@ from tests.base_test import BaseTest
 
 class TestValueExpression(BaseTest):
 
+    # If there is no default value, a value of 'None' should be given.
     def test_value_expression_no_default(self):
 
         workflow = self.create_workflow('test_value_expression')
@@ -14,7 +15,7 @@ class TestValueExpression(BaseTest):
         workflow_api = self.get_workflow_api(workflow)
         second_task = workflow_api.next_task
         self.assertEqual('', second_task.data['value_expression_value'])
-        self.assertNotIn('color', second_task.data)
+        self.assertIn('color', second_task.data)
 
 
 


### PR DESCRIPTION
Well really what this does is give every field a default value of None. what that does is allow you to use value expressions even without a given default value. this part in the backend fixes validation.