### PR TITLE
User studies endpoint #561

### DIFF
--- a/crc/models/protocol_builder.py
+++ b/crc/models/protocol_builder.py
@@ -23,43 +23,36 @@ class ProtocolBuilderStatus(enum.Enum):
     # • Hold: store boolean value in CR Connect (add to Study Model)
     # • Open To Enrollment: has start date?
     # • Abandoned: deleted in PB
-    incomplete = 'incomplete' # Found in PB but not ready to start (not q_complete)
+    incomplete = 'incomplete'  # Found in PB but not ready to start (not q_complete)
     active = 'active'  # found in PB, marked as "q_complete" and not hold
     hold = 'hold'  # CR Connect side, if the Study ias marked as "hold".
     open = 'open'  # Open To Enrollment: has start date?
     abandoned = 'abandoned'  # Not found in PB
 
-
-    #DRAFT = 'draft',                      # !Q_COMPLETE
-    #IN_PROCESS = 'in_process',            # Q_COMPLETE && !UPLOAD_COMPLETE
-    #IN_REVIEW = 'in_review',              # Q_COMPLETE && (!UPLOAD_COMPLETE)
-    #REVIEW_COMPLETE = 'review_complete',  # Q_COMPLETE && UPLOAD_COMPLETE
-    #INACTIVE = 'inactive',                # Not found in PB
-
+    # DRAFT = 'draft',                      # !Q_COMPLETE
+    # IN_PROCESS = 'in_process',            # Q_COMPLETE && !UPLOAD_COMPLETE
+    # IN_REVIEW = 'in_review',              # Q_COMPLETE && (!UPLOAD_COMPLETE)
+    # REVIEW_COMPLETE = 'review_complete',  # Q_COMPLETE && UPLOAD_COMPLETE
+    # INACTIVE = 'inactive',                # Not found in PB
 
 
-class ProtocolBuilderStudy(object):
-    def __init__(
-            self, STUDYID: int, TITLE: str, NETBADGEID: str,
-            DATE_MODIFIED: str, Q_COMPLETE: str, HSRNUMBER: str
-    ):
+class ProtocolBuilderCreatorStudy(object):
+
+    def __init__(self, STUDYID, DATELASTMODIFIED, DATECREATED, TITLE):
         self.STUDYID = STUDYID
+        self.DATELASTMODIFIED = DATELASTMODIFIED
+        self.DATECREATED = DATECREATED
         self.TITLE = TITLE
-        self.NETBADGEID = NETBADGEID
-        self.DATE_MODIFIED = DATE_MODIFIED
-        self.Q_COMPLETE = Q_COMPLETE
-        self.HSRNUMBER = HSRNUMBER
 
-class ProtocolBuilderStudySchema(ma.Schema):
+
+class ProtocolBuilderCreatorStudySchema(ma.Schema):
     class Meta:
-        model = ProtocolBuilderStudy
         unknown = INCLUDE
-        fields = ["STUDYID", "TITLE", "NETBADGEID",
-                  "DATE_MODIFIED", "Q_COMPLETE"]
+        fields = ["STUDYID", "DATELASTMODIFIED", "DATECREATED", "TITLE"]
 
     @post_load
-    def make_pbs(self, data, **kwargs):
-        return ProtocolBuilderStudy(**data)
+    def make_study(self, data, **kwargs):
+        return ProtocolBuilderCreatorStudy(**data)
 
 
 class ProtocolBuilderInvestigator(object):
@@ -88,7 +81,7 @@ class ProtocolBuilderRequiredDocument(object):
 
 class ProtocolBuilderRequiredDocumentSchema(ma.Schema):
     class Meta:
-        fields = ["AUXDOCID","AUXDOC"]
+        fields = ["AUXDOCID", "AUXDOC"]
         unknown = INCLUDE
 
     @post_load

--- a/crc/models/study.py
+++ b/crc/models/study.py
@@ -11,7 +11,7 @@ from crc import db, ma
 from crc.api.common import ApiErrorSchema, ApiError
 from crc.models.file import FileModel, SimpleFileSchema, FileSchema
 from crc.models.ldap import LdapModel, LdapSchema
-from crc.models.protocol_builder import ProtocolBuilderStatus, ProtocolBuilderStudy
+from crc.models.protocol_builder import ProtocolBuilderCreatorStudy
 from crc.models.workflow import WorkflowSpecCategoryModel, WorkflowState, WorkflowStatus, WorkflowSpecModel, \
     WorkflowModel
 from crc.services.file_service import FileService
@@ -57,10 +57,10 @@ class StudyModel(db.Model):
     short_name = db.Column(db.String, nullable=True)
     proposal_name = db.Column(db.String, nullable=True)
 
-    def update_from_protocol_builder(self, pbs: ProtocolBuilderStudy):
-        self.title = pbs.TITLE
-        self.user_uid = pbs.NETBADGEID
-        self.last_updated = pbs.DATE_MODIFIED
+    def update_from_protocol_builder(self, study: ProtocolBuilderCreatorStudy, user_id):
+        self.title = study.TITLE
+        self.user_uid = user_id
+        self.last_updated = study.DATELASTMODIFIED
 
         self.irb_status = IrbStatus.incomplete_in_protocol_builder
 

--- a/crc/services/protocol_builder.py
+++ b/crc/services/protocol_builder.py
@@ -6,7 +6,8 @@ import requests
 
 from crc import app
 from crc.api.common import ApiError
-from crc.models.protocol_builder import ProtocolBuilderStudySchema, ProtocolBuilderRequiredDocument
+from crc.models.protocol_builder import ProtocolBuilderCreatorStudySchema, ProtocolBuilderRequiredDocument
+
 
 class ProtocolBuilderService(object):
     STUDY_URL = app.config['PB_USER_STUDIES_URL']
@@ -33,7 +34,7 @@ class ProtocolBuilderService(object):
         response = requests.get(url)
         if response.ok and response.text:
             try:
-                pb_studies = ProtocolBuilderStudySchema(many=True).loads(response.text)
+                pb_studies = ProtocolBuilderCreatorStudySchema(many=True).loads(response.text)
                 return pb_studies
             except JSONDecodeError as err:
                 raise ApiError("protocol_builder_error",

--- a/crc/services/study_service.py
+++ b/crc/services/study_service.py
@@ -1,9 +1,7 @@
-import urllib
 from copy import copy
 from datetime import datetime
 from typing import List
 
-import flask
 import requests
 from SpiffWorkflow import WorkflowException
 from SpiffWorkflow.bpmn.PythonScriptEngine import Box
@@ -12,15 +10,14 @@ from ldap3.core.exceptions import LDAPSocketOpenError
 
 from crc import db, session, app
 from crc.api.common import ApiError
-from crc.models.data_store import DataStoreModel
 from crc.models.email import EmailModel
 from crc.models.file import FileModel, File, FileSchema
 from crc.models.ldap import LdapSchema
 
-from crc.models.protocol_builder import ProtocolBuilderStudy, ProtocolBuilderStatus
+from crc.models.protocol_builder import ProtocolBuilderCreatorStudy
 from crc.models.study import StudyModel, Study, StudyStatus, Category, WorkflowMetadata, StudyEventType, StudyEvent, \
-    IrbStatus, StudyAssociated, StudyAssociatedSchema
-from crc.models.task_event import TaskEventModel, TaskEvent
+    StudyAssociated
+from crc.models.task_event import TaskEventModel
 from crc.models.task_log import TaskLogModel
 from crc.models.workflow import WorkflowSpecCategoryModel, WorkflowModel, WorkflowSpecModel, WorkflowState, \
     WorkflowStatus, WorkflowSpecDependencyFile
@@ -375,7 +372,7 @@ class StudyService(object):
                             str(app.config['PB_ENABLED']))
 
             # Get studies matching this user from Protocol Builder
-            pb_studies: List[ProtocolBuilderStudy] = ProtocolBuilderService.get_studies(user.uid)
+            pb_studies: List[ProtocolBuilderCreatorStudy] = ProtocolBuilderService.get_studies(user.uid)
 
             # Get studies from the database
             db_studies = session.query(StudyModel).filter_by(user_uid=user.uid).all()
@@ -393,7 +390,7 @@ class StudyService(object):
                     session.add(db_study)
                     db_studies.append(db_study)
 
-                db_study.update_from_protocol_builder(pb_study)
+                db_study.update_from_protocol_builder(pb_study, user.uid)
                 StudyService._add_all_workflow_specs_to_study(db_study)
 
                 # If there is a new automatic status change and there isn't a manual change in place, record it.

--- a/tests/data/pb_responses/user_studies.json
+++ b/tests/data/pb_responses/user_studies.json
@@ -1,26 +1,20 @@
 [
   {
-    "DATE_MODIFIED": "2020-02-19T14:26:49.127756",
-    "NETBADGEID": "dhf8r",
+    "DATECREATED": "2020-02-19T14:26:49.127756",
+    "DATELASTMODIFIED": "2020-02-19T14:26:49.127756",
     "STUDYID": 54321,
-    "TITLE": "Another study about the effect of a naked mannequin on software productivity",
-    "Q_COMPLETE": 0,
-    "HSRNUMBER": null
+    "TITLE": "Another study about the effect of a naked mannequin on software productivity"
   },
   {
-    "DATE_MODIFIED": "2020-02-19T14:24:55.101695",
-    "NETBADGEID": "dhf8r",
+    "DATECREATED": "2020-02-19T14:24:55.101695",
+    "DATELASTMODIFIED": "2020-02-19T14:24:55.101695",
     "STUDYID": 65432,
-    "TITLE": "Peanut butter consumption among quiet dogs",
-    "Q_COMPLETE": 0,
-    "HSRNUMBER": null
+    "TITLE": "Peanut butter consumption among quiet dogs"
   },
   {
-    "DATE_MODIFIED": "2020-02-19T14:24:55.101695",
-    "NETBADGEID": "dhf8r",
+    "DATECREATED": "2020-02-19T14:24:55.101695",
+    "DATELASTMODIFIED": "2020-02-19T14:24:55.101695",
     "STUDYID": 1,
-    "TITLE": "Efficacy of xenomorph bio-augmented circuits on dexterity of cybernetic prostheses",
-    "Q_COMPLETE": 0,
-    "HSRNUMBER": null
+    "TITLE": "Efficacy of xenomorph bio-augmented circuits on dexterity of cybernetic prostheses"
   }
 ]

--- a/tests/study/test_study_details.py
+++ b/tests/study/test_study_details.py
@@ -6,12 +6,8 @@ from tests.base_test import BaseTest
 from unittest.mock import patch
 
 from crc import app, session
-from crc.api.common import ApiError
-from crc.models.file import FileDataModel, FileModel
-from crc.models.protocol_builder import ProtocolBuilderRequiredDocumentSchema, ProtocolBuilderStudySchema
 from crc.models.study import StudyModel
 from crc.scripts.study_info import StudyInfo
-from crc.services.file_service import FileService
 from crc.services.study_service import StudyService
 from crc.services.workflow_processor import WorkflowProcessor
 

--- a/tests/workflow/test_workflow_processor.py
+++ b/tests/workflow/test_workflow_processor.py
@@ -11,8 +11,7 @@ from SpiffWorkflow.camunda.specs.UserTask import FormField
 from crc import session, db, app
 from crc.api.common import ApiError
 from crc.models.file import FileModel, FileDataModel
-from crc.models.protocol_builder import ProtocolBuilderStudySchema
-from crc.services.protocol_builder import ProtocolBuilderService
+from crc.models.protocol_builder import ProtocolBuilderCreatorStudySchema
 from crc.models.study import StudyModel
 from crc.models.workflow import WorkflowSpecModel, WorkflowStatus
 from crc.services.file_service import FileService
@@ -23,11 +22,13 @@ from crc.services.workflow_service import WorkflowService
 
 class TestWorkflowProcessor(BaseTest):
 
-    def _populate_form_with_random_data(self, task):
+    @staticmethod
+    def _populate_form_with_random_data(task):
         api_task = WorkflowService.spiff_task_to_api_task(task, add_docs_and_forms=True)
         WorkflowService.populate_form_with_random_data(task, api_task, required_only=False)
 
-    def get_processor(self, study_model, spec_model):
+    @staticmethod
+    def get_processor(study_model, spec_model):
         workflow_model = StudyService._create_workflow_model(study_model, spec_model)
         return WorkflowProcessor(workflow_model)
 
@@ -346,7 +347,7 @@ class TestWorkflowProcessor(BaseTest):
 
         # Mock Protocol Builder response
         studies_response = self.protocol_builder_response('user_studies.json')
-        mock_studies.return_value = ProtocolBuilderStudySchema(many=True).loads(studies_response)
+        mock_studies.return_value = ProtocolBuilderCreatorStudySchema(many=True).loads(studies_response)
 
         investigators_response = self.protocol_builder_response('investigators.json')
         mock_investigators.return_value = json.loads(investigators_response)

--- a/tests/workflow/test_workflow_spec_validation_api.py
+++ b/tests/workflow/test_workflow_spec_validation_api.py
@@ -1,14 +1,10 @@
 import json
-import unittest
 from unittest.mock import patch
-
-from sqlalchemy import func
 
 from tests.base_test import BaseTest
 
 from crc import session, app
 from crc.api.common import ApiErrorSchema
-from crc.models.protocol_builder import ProtocolBuilderStudySchema
 from crc.models.study import StudyModel
 from crc.models.workflow import WorkflowSpecModel, WorkflowModel
 from crc.services.workflow_service import WorkflowService


### PR DESCRIPTION
Modifications for the new `StudyCreator` endpoint at UVA PB.
The new endpoint returns STUDYID, TITLE, DATECREATED, and DATELASTMODIFIED

Note that we now pass the UVA user id in our call to **update_from_protocol_builder** in **StudyService.synch_with_protocol_builder_if_enabled**

`db_study.update_from_protocol_builder(pb_study, user.uid)`