### PR TITLE
The LDAP service didn't do a good enough check to see if the record w…

### DIFF
--- a/crc/services/ldap_service.py
+++ b/crc/services/ldap_service.py
@@ -54,7 +54,7 @@ class LdapService(object):
 
     @staticmethod
     def user_info(uva_uid):
-        uva_uid = uva_uid.lower()
+        uva_uid = uva_uid.strip().lower()
         user_info = db.session.query(LdapModel).filter(LdapModel.uid == uva_uid).first()
         if not user_info:
             app.logger.info("No cache for " + uva_uid)
@@ -64,9 +64,13 @@ class LdapService(object):
             if len(conn.entries) < 1:
                 raise ApiError("missing_ldap_record", "Unable to locate a user with id %s in LDAP" % uva_uid)
             entry = conn.entries[0]
-            user_info = LdapModel.from_entry(entry)
-            db.session.add(user_info)
-            db.session.commit()
+            # Assure it definitely doesn't exist in the db after a search, in some cases the ldap server
+            # may find stuff we don't with just a strip and a lower.
+            user_info = db.session.query(LdapModel).filter(LdapModel.uid == entry.uid.value).first()
+            if not user_info:
+                user_info = LdapModel.from_entry(entry)
+                db.session.add(user_info)
+                db.session.commit()
         return user_info
 
     @staticmethod

--- a/tests/test_ldap_service.py
+++ b/tests/test_ldap_service.py
@@ -36,3 +36,12 @@ class TestLdapService(BaseTest):
         user_info = LdapService.user_info("LB3DP")
         self.assertIsNotNone(user_info)
         self.assertEqual("lb3dp", user_info.uid)
+
+    def test_get_user_with_spaces(self):
+        user_info = LdapService.user_info("    LB3DP ")
+        # Call this a second time, becuase the error we ran into wasn't that it wasn't possible to find it,
+        # but that it attepts to add it to the database a second time with the same id.
+        user_info = LdapService.user_info("    LB3DP ")
+        self.assertIsNotNone(user_info)
+        self.assertEqual("lb3dp", user_info.uid)
+


### PR DESCRIPTION
…as already in the database.  This caused an error, which left the workflow in a waiting state.  And that waiting state meant the error would just happen a million times over again until we pushed up this code change.