### PR TITLE
Disable Scheduled Tasks in Development Mode (if desired). 

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -98,3 +98,6 @@ MAIL_PASSWORD = environ.get('MAIL_PASSWORD', default='')
 
 # Local file path
 SYNC_FILE_ROOT = environ.get('SYNC_FILE_ROOT', default='tests/data/IMPORT_TEST')
+
+# Turn on/off processing waiting tasks
+PROCESS_WAITING_TASKS = environ.get('PROCESS_WAITING_TASKS', default='true')

--- a/crc/__init__.py
+++ b/crc/__init__.py
@@ -65,9 +65,9 @@ def process_waiting_tasks():
 
 @app.before_first_request
 def init_scheduler():
-    scheduler.add_job(process_waiting_tasks, 'interval', minutes=1)
-    # scheduler.add_job(FileService.cleanup_file_data, 'interval', minutes=1440)  # once a day
-    scheduler.start()
+    if app.config['PROCESS_WAITING_TASKS']:
+        scheduler.add_job(process_waiting_tasks, 'interval', minutes=1)
+        scheduler.start()
 
 
 # Convert list of allowed origins to list of regexes


### PR DESCRIPTION
By default the system will start up the scheduled tasks, which is usually what you want, but in development

it can be kind of irritating for this stuff to be spinning up when you are trying to debug something, so just set
PROCESS_WAITING_TASKS to false in instance/config.py and voila!!