### PR TITLE
Bug/missing executabe option #601

### DIFF
--- a/crc/services/spec_file_service.py
+++ b/crc/services/spec_file_service.py
@@ -113,6 +113,13 @@ class SpecFileService(FileSystemService):
 
             except etree.XMLSyntaxError as xse:
                 raise ApiError("invalid_xml", "Failed to parse xml: " + str(xse), file_name=file_name)
+            except ValidationException as ve:
+                if ve.args[0].find('No executable process tag found') >= 0:
+                    raise ApiError(code='missing_executable_option',
+                                   message='No executable process tag found. Please make sure the Executable option is set in the workflow.')
+                else:
+                    raise ApiError(code='validation_error',
+                                   message=f'There was an error validating your workflow. Original message is: {ve}')
         else:
             raise ApiError("invalid_xml", "Only a BPMN can be the primary file.", file_name=file_name)
 

--- a/tests/data/missing_executable_tag/missing_executable_tag.bpmn
+++ b/tests/data/missing_executable_tag/missing_executable_tag.bpmn
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_0g5rfar" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
+  <bpmn:process id="Process_05y6lb7">
+    <bpmn:startEvent id="StartEvent_1">
+      <bpmn:outgoing>Flow_0djwo51</bpmn:outgoing>
+    </bpmn:startEvent>
+    <bpmn:sequenceFlow id="Flow_0djwo51" sourceRef="StartEvent_1" targetRef="Activity_1gst0w5" />
+    <bpmn:endEvent id="Event_1fetqlx">
+      <bpmn:incoming>Flow_19hnovy</bpmn:incoming>
+    </bpmn:endEvent>
+    <bpmn:sequenceFlow id="Flow_19hnovy" sourceRef="Activity_1gst0w5" targetRef="Event_1fetqlx" />
+    <bpmn:manualTask id="Activity_1gst0w5" name="Hello World">
+      <bpmn:documentation>## Hello World</bpmn:documentation>
+      <bpmn:incoming>Flow_0djwo51</bpmn:incoming>
+      <bpmn:outgoing>Flow_19hnovy</bpmn:outgoing>
+    </bpmn:manualTask>
+  </bpmn:process>
+  <bpmndi:BPMNDiagram id="BPMNDiagram_1">
+    <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_05y6lb7">
+      <bpmndi:BPMNEdge id="Flow_0djwo51_di" bpmnElement="Flow_0djwo51">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="270" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_19hnovy_di" bpmnElement="Flow_19hnovy">
+        <di:waypoint x="370" y="117" />
+        <di:waypoint x="432" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
+        <dc:Bounds x="179" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Event_1fetqlx_di" bpmnElement="Event_1fetqlx">
+        <dc:Bounds x="432" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_07hce4z_di" bpmnElement="Activity_1gst0w5">
+        <dc:Bounds x="270" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+    </bpmndi:BPMNPlane>
+  </bpmndi:BPMNDiagram>
+</bpmn:definitions>

--- a/tests/workflow/test_workflow_missing_executable_tag.py
+++ b/tests/workflow/test_workflow_missing_executable_tag.py
@@ -1,0 +1,12 @@
+from tests.base_test import BaseTest
+
+from crc.api.common import ApiError
+
+
+class TestMissingExecutable(BaseTest):
+
+    def test_missing_executable(self):
+        with self.assertRaises(ApiError) as ae:
+            self.create_workflow('missing_executable_tag')
+        self.assertEqual('No executable process tag found. Please make sure the Executable option is set in the workflow.',
+                         ae.exception.message)


### PR DESCRIPTION
Raise an ApiError if the isExecutable tag is missing in the BPMN for a workflow.
Unsure how this would actually happen, since the tag should be set to False if the box is unchecked.