### PR TITLE
modify spreadsheet #624

### DIFF
--- a/crc/scripts/modify_spreadsheet.py
+++ b/crc/scripts/modify_spreadsheet.py
@@ -14,7 +14,7 @@ class ModifySpreadsheet(Script):
     def get_parameters(args, kwargs):
         parameters = {}
         if len(args) == 3 or ('irb_doc_code' in kwargs and 'cell' in kwargs and 'text' in kwargs):
-            if 'irb_doc_code' in kwargs and 'line' in kwargs and 'text' in kwargs:
+            if 'irb_doc_code' in kwargs and 'cell' in kwargs and 'text' in kwargs:
                 parameters['irb_doc_code'] = (kwargs['irb_doc_code'])
                 parameters['cell'] = (kwargs['cell'])
                 parameters['text'] = (kwargs['text'])

--- a/tests/data/modify_spreadsheet/modify_spreadsheet.bpmn
+++ b/tests/data/modify_spreadsheet/modify_spreadsheet.bpmn
@@ -27,7 +27,7 @@
     <bpmn:scriptTask id="Activity_ModifySpreadsheet" name="Modify Spreadsheet">
       <bpmn:incoming>Flow_0fpc32g</bpmn:incoming>
       <bpmn:outgoing>Flow_10ulj3l</bpmn:outgoing>
-      <bpmn:script>modify_spreadsheet('Finance_BCA', cell_indicator, input_text)</bpmn:script>
+      <bpmn:script>modify_spreadsheet(irb_doc_code='Finance_BCA', cell=cell_indicator, text=input_text)</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:userTask id="Activity_GetModifyData" name="Get Modify Data" camunda:formKey="ModifyData">
       <bpmn:documentation>## File Upload


### PR DESCRIPTION
Typo calling script with keywords
The script was using the old 'line' when validating keywords.
Changed it to 'cell' which is more representative of the current way we use the script