### PR TITLE
An optimization prevented us from picking up a change to the document…

### DIFF
--- a/crc/scripts/complete_template.py
+++ b/crc/scripts/complete_template.py
@@ -10,6 +10,7 @@ from crc.models.workflow import WorkflowModel
 from crc.scripts.script import Script
 from crc.services.jinja_service import JinjaService
 from crc.services.spec_file_service import SpecFileService
+from crc.services.study_service import StudyService
 from crc.services.user_file_service import UserFileService
 from crc.services.workflow_processor import WorkflowProcessor
 from crc.services.workflow_spec_service import WorkflowSpecService
@@ -43,6 +44,8 @@ Takes two arguments:
                                           content_type=CONTENT_TYPES['docx'],
                                           binary_data=final_document_stream.read(),
                                           irb_doc_code=irb_doc_code)
+        # Force the list of document statuses to update, now that we have a new file
+        StudyService.get_documents_status(study_id=study_id, force=True)
 
     def process_template(self, task, study_id, workflow=None, *args, **kwargs):
         """Entry point, mostly worried about wiring it all up."""

--- a/crc/scripts/get_zipped_files.py
+++ b/crc/scripts/get_zipped_files.py
@@ -51,6 +51,7 @@ class GetZippedFiles(Script):
                         file_model = UserFileService().add_workflow_file(workflow_id, None, task.get_name(),
                                                                          zip_filename, 'application/zip', handle.read())
                         # return file_model
+                        StudyService.get_documents_status(study_id=study_id, force=True)
                         return FileSchema().dump(to_file_api(file_model))
         else:
             raise ApiError(code='missing_file_ids',

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -458,7 +458,7 @@ class WorkflowService(object):
         try:
             return task.workflow.script_engine._evaluate(expression, **data)
         except Exception as e:
-            message = f"The field {field.id} contains an invalid expression. {e}"
+            message = f"The field {field.id} contains an invalid expression: '{expression}'.  {e}"
             raise ApiError.from_task(f'invalid_{property_name}', message, task=task)
 
     @staticmethod

--- a/tests/test_complete_template_script.py
+++ b/tests/test_complete_template_script.py
@@ -40,6 +40,7 @@ class TestCompleteTemplate(unittest.TestCase):
 class TestEmbeddedTemplate(BaseTest):
 
     def test_embedded_template(self):
+        self.create_reference_document()
         workflow = self.create_workflow('docx_embedded')
         workflow_api = self.get_workflow_api(workflow)
         task = workflow_api.next_task

--- a/tests/workflow/test_workflow_processor.py
+++ b/tests/workflow/test_workflow_processor.py
@@ -206,7 +206,7 @@ class TestWorkflowProcessor(BaseTest):
         self.assertEqual("task_error", context.exception.code)
 
     def test_workflow_with_docx_template(self):
-
+        self.create_reference_document()
         study = session.query(StudyModel).first()
         workflow_spec_model = self.load_test_spec("docx")
         files = SpecFileService.get_files(workflow_spec_model)


### PR DESCRIPTION
…s associated with a study.  This assures that even if scripts run side by side, the document list will get updated, but only on a change.  So it's still performant.  Also added a sligthly better error message to the workflow service.