### PR TITLE
Chore/add metrics to logging level #665

### DIFF
--- a/crc/models/task_log.py
+++ b/crc/models/task_log.py
@@ -19,6 +19,7 @@ class TaskLogLevels(enum.Enum, metaclass=MyEnumMeta):
     warning = 30
     info = 20
     debug = 10
+    metrics = 5
 
 
 class TaskLogModel(db.Model):

--- a/tests/data/logging_task/logging_task.bpmn
+++ b/tests/data/logging_task/logging_task.bpmn
@@ -1,20 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_e3059e6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="3.0.0-dev">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" id="Definitions_e3059e6" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="Process_LoggingTask" name="Logging Task" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_1vjxvjd</bpmn:outgoing>
     </bpmn:startEvent>
-    <bpmn:sequenceFlow id="Flow_1vjxvjd" sourceRef="StartEvent_1" targetRef="Activity_LogEvent" />
+    <bpmn:sequenceFlow id="Flow_1vjxvjd" sourceRef="StartEvent_1" targetRef="Activity_GetLogData" />
     <bpmn:scriptTask id="Activity_LogEvent" name="Log Event">
-      <bpmn:incoming>Flow_1vjxvjd</bpmn:incoming>
+      <bpmn:incoming>Flow_126w4xi</bpmn:incoming>
       <bpmn:outgoing>Flow_1mw0dlv</bpmn:outgoing>
-      <bpmn:script>log_model = log(level='info', code='test_code', message='You forgot to include the correct data.')</bpmn:script>
+      <bpmn:script>log_model = log(level=level, code=code, message=message)</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_1mw0dlv" sourceRef="Activity_LogEvent" targetRef="Activity_DisplayLog" />
     <bpmn:manualTask id="Activity_DisplayLog" name="DisplayLog">
       <bpmn:documentation># Log Model
-{{ log_model }}
-</bpmn:documentation>
+{{ log_model }}</bpmn:documentation>
       <bpmn:incoming>Flow_1mw0dlv</bpmn:incoming>
       <bpmn:outgoing>Flow_016ui0e</bpmn:outgoing>
     </bpmn:manualTask>
@@ -22,32 +21,63 @@
       <bpmn:incoming>Flow_016ui0e</bpmn:incoming>
     </bpmn:endEvent>
     <bpmn:sequenceFlow id="Flow_016ui0e" sourceRef="Activity_DisplayLog" targetRef="Event_06g3ojm" />
+    <bpmn:sequenceFlow id="Flow_126w4xi" sourceRef="Activity_GetLogData" targetRef="Activity_LogEvent" />
+    <bpmn:userTask id="Activity_GetLogData" name="Get Log Data" camunda:formKey="LogDataForm">
+      <bpmn:extensionElements>
+        <camunda:formData>
+          <camunda:formField id="level" label="&#39;Level&#39;" type="string" defaultValue="&#39;info&#39;">
+            <camunda:validation>
+              <camunda:constraint name="required" config="True" />
+            </camunda:validation>
+          </camunda:formField>
+          <camunda:formField id="code" label="&#39;Code&#39;" type="string">
+            <camunda:validation>
+              <camunda:constraint name="required" config="True" />
+            </camunda:validation>
+          </camunda:formField>
+          <camunda:formField id="message" label="&#39;Message&#39;" type="string">
+            <camunda:validation>
+              <camunda:constraint name="required" config="True" />
+            </camunda:validation>
+          </camunda:formField>
+        </camunda:formData>
+      </bpmn:extensionElements>
+      <bpmn:incoming>Flow_1vjxvjd</bpmn:incoming>
+      <bpmn:outgoing>Flow_126w4xi</bpmn:outgoing>
+    </bpmn:userTask>
   </bpmn:process>
   <bpmndi:BPMNDiagram id="BPMNDiagram_1">
     <bpmndi:BPMNPlane id="BPMNPlane_1" bpmnElement="Process_LoggingTask">
-      <bpmndi:BPMNEdge id="Flow_016ui0e_di" bpmnElement="Flow_016ui0e">
-        <di:waypoint x="530" y="177" />
-        <di:waypoint x="592" y="177" />
+      <bpmndi:BPMNEdge id="Flow_1vjxvjd_di" bpmnElement="Flow_1vjxvjd">
+        <di:waypoint x="215" y="117" />
+        <di:waypoint x="274" y="117" />
+      </bpmndi:BPMNEdge>
+      <bpmndi:BPMNEdge id="Flow_126w4xi_di" bpmnElement="Flow_126w4xi">
+        <di:waypoint x="374" y="117" />
+        <di:waypoint x="438" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNEdge id="Flow_1mw0dlv_di" bpmnElement="Flow_1mw0dlv">
-        <di:waypoint x="370" y="177" />
-        <di:waypoint x="430" y="177" />
+        <di:waypoint x="538" y="117" />
+        <di:waypoint x="602" y="117" />
       </bpmndi:BPMNEdge>
-      <bpmndi:BPMNEdge id="Flow_1vjxvjd_di" bpmnElement="Flow_1vjxvjd">
-        <di:waypoint x="215" y="177" />
-        <di:waypoint x="270" y="177" />
+      <bpmndi:BPMNEdge id="Flow_016ui0e_di" bpmnElement="Flow_016ui0e">
+        <di:waypoint x="702" y="117" />
+        <di:waypoint x="762" y="117" />
       </bpmndi:BPMNEdge>
       <bpmndi:BPMNShape id="_BPMNShape_StartEvent_2" bpmnElement="StartEvent_1">
-        <dc:Bounds x="179" y="159" width="36" height="36" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_08z1eq4_di" bpmnElement="Activity_LogEvent">
-        <dc:Bounds x="270" y="137" width="100" height="80" />
-      </bpmndi:BPMNShape>
-      <bpmndi:BPMNShape id="Activity_0amiq7i_di" bpmnElement="Activity_DisplayLog">
-        <dc:Bounds x="430" y="137" width="100" height="80" />
+        <dc:Bounds x="179" y="99" width="36" height="36" />
       </bpmndi:BPMNShape>
       <bpmndi:BPMNShape id="Event_06g3ojm_di" bpmnElement="Event_06g3ojm">
-        <dc:Bounds x="592" y="159" width="36" height="36" />
+        <dc:Bounds x="762" y="99" width="36" height="36" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_08z1eq4_di" bpmnElement="Activity_LogEvent">
+        <dc:Bounds x="438" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0amiq7i_di" bpmnElement="Activity_DisplayLog">
+        <dc:Bounds x="602" y="77" width="100" height="80" />
+      </bpmndi:BPMNShape>
+      <bpmndi:BPMNShape id="Activity_0trhnak_di" bpmnElement="Activity_GetLogData">
+        <dc:Bounds x="274" y="77" width="100" height="80" />
       </bpmndi:BPMNShape>
     </bpmndi:BPMNPlane>
   </bpmndi:BPMNDiagram>

--- a/tests/scripts/test_task_logging.py
+++ b/tests/scripts/test_task_logging.py
@@ -3,15 +3,12 @@ import json
 from tests.base_test import BaseTest
 
 from crc.models.user import UserModel
-from crc import session, WorkflowService
-from crc.models.api_models import Task, TaskSchema
-from crc.models.task_log import TaskLogModel, TaskLogModelSchema, TaskLogQuery, TaskLogQuerySchema
+from crc import session
+from crc.models.task_log import TaskLogModel, TaskLogQuery, TaskLogQuerySchema
 from crc.models.study import StudyModel
 from crc.scripts.log import TaskLog
 from crc.services.workflow_processor import WorkflowProcessor
 from crc.services.task_logging_service import TaskLoggingService
-
-import types
 
 
 class TestTaskLogging(BaseTest):
@@ -37,8 +34,8 @@ class TestTaskLogging(BaseTest):
 
     def test_add_log(self):
         log_data = {'level': 'info',
-                     'code': 'test_code',
-                     'message': 'You forgot to include the correct data.'}
+                    'code': 'test_code',
+                    'message': 'You forgot to include the correct data.'}
         log_id = self.add_log(log_data)
         log_model = session.query(TaskLogModel).filter(TaskLogModel.id == log_id).first()
 
@@ -47,10 +44,9 @@ class TestTaskLogging(BaseTest):
         self.assertEqual('Activity_LogEvent', log_model.task)
 
     def test_add_metrics_log(self):
-
         log_data = {'level': 'metrics',
-                     'code': 'test_code',
-                     'message': 'You forgot to include the correct data.'}
+                    'code': 'test_code',
+                    'message': 'You forgot to include the correct data.'}
         log_id = self.add_log(log_data)
         log_model = session.query(TaskLogModel).filter(TaskLogModel.id == log_id).first()
 


### PR DESCRIPTION
Allow `metrics` as a log level.
Modified the test workflow to allow us to pass in the logging data--level, code, and message.
Fixed tests to use the new workflow
Added test for log with `metrics` as log level