### PR TITLE
Optionally filter out task events that don't have a task lane

### DIFF
--- a/crc/api.yml
+++ b/crc/api.yml
@@ -1147,7 +1147,7 @@ paths:
         description: Restrict results to the given study.
         schema:
           type: number
-      - name: nonulls
+      - name: onlylanes
         in: query
         required: false
         description: Restrict results to not include null task lanes.

--- a/crc/api.yml
+++ b/crc/api.yml
@@ -1147,6 +1147,12 @@ paths:
         description: Restrict results to the given study.
         schema:
           type: number
+      - name: nonulls
+        in: query
+        required: false
+        description: Restrict results to not include null task lanes.
+        schema:
+          type: boolean
     get:
       operationId: crc.api.workflow.get_task_events
       summary: Returns a list of task events related to the current user.  Can be filtered by type.

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -215,7 +215,7 @@ def restart_workflow(workflow_id, clear_data=False, delete_files=False):
     return api_model
 
 
-def get_task_events(action = None, workflow = None, study = None, nonulls = None):
+def get_task_events(action = None, workflow = None, study = None, onlylanes = None):
     """Provides a way to see a history of what has happened, or get a list of tasks that need your attention."""
     user = UserService.current_user(allow_admin_impersonate=True)
     studies = session.query(StudyModel).filter(StudyModel.user_uid==user.uid)
@@ -228,7 +228,7 @@ def get_task_events(action = None, workflow = None, study = None, nonulls = None
         query = query.filter(TaskEventModel.workflow_id == workflow)
     if study:
         query = query.filter(TaskEventModel.study_id == study)
-    if nonulls:
+    if onlylanes:
         query = query.filter(TaskEventModel.task_lane != None)
     events = query.all()
 

--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -215,7 +215,7 @@ def restart_workflow(workflow_id, clear_data=False, delete_files=False):
     return api_model
 
 
-def get_task_events(action = None, workflow = None, study = None):
+def get_task_events(action = None, workflow = None, study = None, nonulls = None):
     """Provides a way to see a history of what has happened, or get a list of tasks that need your attention."""
     user = UserService.current_user(allow_admin_impersonate=True)
     studies = session.query(StudyModel).filter(StudyModel.user_uid==user.uid)
@@ -228,6 +228,8 @@ def get_task_events(action = None, workflow = None, study = None):
         query = query.filter(TaskEventModel.workflow_id == workflow)
     if study:
         query = query.filter(TaskEventModel.study_id == study)
+    if nonulls:
+        query = query.filter(TaskEventModel.task_lane != None)
     events = query.all()
 
     # Turn the database records into something a little richer for the UI to use.


### PR DESCRIPTION
When loading the main dashboard, we only need to see approvals that have a task waiting in another lane. Rather than passing over a big chunk of task events and having the frontend filter them, just send back the filtered data from the backend