### PR TITLE
Get irb info issue #702

### DIFF
--- a/crc/scripts/get_irb_info.py
+++ b/crc/scripts/get_irb_info.py
@@ -19,7 +19,10 @@ class IRBInfo(Script):
     def do_task(self, task, study_id, workflow_id, *args, **kwargs):
         irb_info = self.pb.get_irb_info(study_id)
         if irb_info:
-            return irb_info
+            if isinstance(irb_info, dict):
+                return irb_info
+            elif isinstance(irb_info, list) and len(irb_info) > 0:
+                return irb_info[0]
         else:
             raise WorkflowTaskExecException(task, f'get_irb_info failed.  There was a problem retrieving IRB Info'
                                                   f' for study {study_id}.')

--- a/tests/data/pb_responses/irb_info.json
+++ b/tests/data/pb_responses/irb_info.json
@@ -1,7 +1,7 @@
 [
   {
-    "AGENDA_DATE": "2021-04-15T00:00:00+00:00",
-    "DATE_MODIFIED": "2021-04-15T00:00:00+00:00",
+    "AGENDA_DATE": "April, 25 2021 14:00:00",
+    "DATE_MODIFIED": "April, 05 2021 14:02:00",
     "IRBEVENT": "IRB Event 1",
     "IRB_ADMINISTRATIVE_REVIEWER": "IRB Admin Reviewer 1",
     "IRB_OF_RECORD": "IRB of Record 1",
@@ -9,30 +9,9 @@
     "IRB_STATUS": "IRB Status 1",
     "STUDYIRBREVIEWERADMIN": "Study IRB Review Admin 1",
     "UVA_IRB_HSR_IS_IRB_OF_RECORD_FOR_ALL_SITES": 1,
-    "UVA_STUDY_TRACKING": "UVA Study Tracking 1"
-  },
-  {
-    "AGENDA_DATE": "2021-04-15T00:00:00+00:00",
-    "DATE_MODIFIED": "2021-04-15T00:00:00+00:00",
-    "IRBEVENT": "IRB Event 2",
-    "IRB_ADMINISTRATIVE_REVIEWER": "IRB Admin Reviewer 2",
-    "IRB_OF_RECORD": "IRB of Record 2",
-    "IRB_REVIEW_TYPE": "IRB Review Type 2",
-    "IRB_STATUS": "IRB Status 2",
-    "STUDYIRBREVIEWERADMIN": "Study IRB Review Admin 2",
-    "UVA_IRB_HSR_IS_IRB_OF_RECORD_FOR_ALL_SITES": 2,
-    "UVA_STUDY_TRACKING": "UVA Study Tracking 2"
-  },
-  {
-    "AGENDA_DATE": "2021-04-15T00:00:00+00:00",
-    "DATE_MODIFIED": "2021-04-15T00:00:00+00:00",
-    "IRBEVENT": "IRB Event 3",
-    "IRB_ADMINISTRATIVE_REVIEWER": "IRB Admin Reviewer 3",
-    "IRB_OF_RECORD": "IRB of Record 3",
-    "IRB_REVIEW_TYPE": "IRB Review Type 3",
-    "IRB_STATUS": "IRB Status 3",
-    "STUDYIRBREVIEWERADMIN": "Study IRB Review Admin 3",
-    "UVA_IRB_HSR_IS_IRB_OF_RECORD_FOR_ALL_SITES": 3,
-    "UVA_STUDY_TRACKING": "UVA Study Tracking 3"
+    "UVA_STUDY_TRACKING": "UVA Study Tracking 1",
+    "SS_STUDY_ID": 12345,
+    "STATUS": "Downloaded",
+    "DETAIL": "Study downloaded to IRB Online."
   }
 ]

--- a/tests/data/pb_responses/irb_info_error.json
+++ b/tests/data/pb_responses/irb_info_error.json
@@ -1,0 +1,4 @@
+{
+  "STATUS": "Error",
+  "DETAIL": "Study not downloaded to IRB Online."
+}

--- a/tests/test_irb_info_script.py
+++ b/tests/test_irb_info_script.py
@@ -18,4 +18,22 @@ class TestIRBInfo(BaseTest):
         workflow_api = self.get_workflow_api(workflow)
         first_task = workflow_api.next_task
         self.assertEqual('Task_PrintInfo', first_task.name)
-        self.assertEqual(f'IRB Info: {irb_info}', first_task.documentation)
+        # The API returns a list, but the get_irb_info script returns the first element in the list
+        self.assertEqual('Downloaded', irb_info[0]['STATUS'])
+        self.assertEqual('IRB Event 1', irb_info[0]['IRBEVENT'])
+        self.assertEqual('IRB Status 1', irb_info[0]['IRB_STATUS'])
+        self.assertEqual(f'IRB Info: {irb_info[0]}', first_task.documentation)
+
+    @patch('crc.services.protocol_builder.requests.get')
+    def test_irb_info_script_no_result(self, mock_get):
+        app.config['PB_ENABLED'] = True
+        mock_get.return_value.ok = True
+        mock_get.return_value.text = self.protocol_builder_response('irb_info_error.json')
+        workflow = self.create_workflow('irb_info_script')
+        irb_info = ProtocolBuilderService.get_irb_info(workflow.study_id)
+        workflow_api = self.get_workflow_api(workflow)
+        first_task = workflow_api.next_task
+        self.assertIn(irb_info['DETAIL'], first_task.documentation)
+        self.assertIn(irb_info['STATUS'], first_task.documentation)
+        self.assertEqual(irb_info['DETAIL'], 'Study not downloaded to IRB Online.')
+        self.assertEqual(irb_info['STATUS'], 'Error')

--- a/tests/test_protocol_builder.py
+++ b/tests/test_protocol_builder.py
@@ -69,10 +69,9 @@ class TestProtocolBuilder(BaseTest):
         mock_get.return_value.text = self.protocol_builder_response('irb_info.json')
         response = ProtocolBuilderService.get_irb_info(self.test_study_id)
         self.assertIsNotNone(response)
-        self.assertEqual(3, len(response))
+        # IRB Info should always return 1 record
+        self.assertEqual(1, len(response))
         self.assertEqual('IRB Event 1', response[0]["IRBEVENT"])
-        self.assertEqual('IRB Event 2', response[1]["IRBEVENT"])
-        self.assertEqual('IRB Event 3', response[2]["IRBEVENT"])
 
     @patch('crc.services.protocol_builder.requests.get')
     def test_check_study(self, mock_get):


### PR DESCRIPTION
Update backend to reflect changes to IRB Info API endpoint

- a dictionary is returned when a study is **not** yet uploaded to IRB Online
- a list is returned when a study **is** uploaded to IRB Online
- the list will contain 1 dictionary
