### PR TITLE
Email name parameter #726

### DIFF
--- a/crc/models/email.py
+++ b/crc/models/email.py
@@ -20,6 +20,7 @@ class EmailModel(db.Model):
     timestamp = db.Column(db.DateTime(timezone=True), default=func.now())
     workflow_spec_id = db.Column(db.String, nullable=True)
     study = db.relationship(StudyModel)
+    name = db.Column(db.String)
 
 
 class EmailModelSchema(ma.Schema):

--- a/crc/scripts/email.py
+++ b/crc/scripts/email.py
@@ -63,6 +63,7 @@ email(subject="My Subject", recipients="user@example.com", attachments=['Study_A
             bcc = []
             reply_to = None
             files = None
+            name = None
             if 'cc' in kwargs and kwargs['cc'] is not None:
                 cc = self.get_email_addresses(kwargs['cc'], study_id)
             if 'bcc' in kwargs and kwargs['bcc'] is not None:
@@ -72,6 +73,8 @@ email(subject="My Subject", recipients="user@example.com", attachments=['Study_A
             # Don't process if attachments is None or ''
             if 'attachments' in kwargs and kwargs['attachments'] is not None and kwargs['attachments'] != '':
                 files = self.get_files(kwargs['attachments'], study_id)
+            if 'name' in kwargs and kwargs['name'] is not None:
+                name = kwargs['name']
 
         else:
             raise ApiError(code="missing_argument",
@@ -95,7 +98,8 @@ email(subject="My Subject", recipients="user@example.com", attachments=['Study_A
                     study_id=study_id,
                     reply_to=reply_to,
                     attachment_files=files,
-                    workflow_spec_id=workflow_spec_id
+                    workflow_spec_id=workflow_spec_id,
+                    name=name
                 )
             except Exception as e:
                 exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/crc/services/email_service.py
+++ b/crc/services/email_service.py
@@ -19,7 +19,7 @@ class EmailService(object):
 
     @staticmethod
     def add_email(subject, sender, recipients, content, content_html,
-                  cc=None, bcc=None, study_id=None, reply_to=None, attachment_files=None, workflow_spec_id=None):
+                  cc=None, bcc=None, study_id=None, reply_to=None, attachment_files=None, workflow_spec_id=None, name=None):
         """We will receive all data related to an email and store it"""
 
         # Find corresponding study - if any
@@ -30,7 +30,7 @@ class EmailService(object):
         # Create EmailModel
         email_model = EmailModel(subject=subject, sender=sender, recipients=str(recipients),
                                  content=content, content_html=content_html, study=study,
-                                 cc=cc, bcc=bcc, workflow_spec_id=workflow_spec_id)
+                                 cc=cc, bcc=bcc, workflow_spec_id=workflow_spec_id, name=name)
 
         # Send mail
         try:

--- a/migrations/versions/cedd03c24166_email_name_column.py
+++ b/migrations/versions/cedd03c24166_email_name_column.py
@@ -1,0 +1,24 @@
+"""email-name-column
+
+Revision ID: cedd03c24166
+Revises: 3489d5a6a2c0
+Create Date: 2022-04-25 15:09:05.597408
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'cedd03c24166'
+down_revision = '3489d5a6a2c0'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('email', sa.Column('name', sa.String(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('email', 'name')

--- a/tests/data/email_script/email_script.bpmn
+++ b/tests/data/email_script/email_script.bpmn
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_bd39673" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.0.0">
+<bpmn:definitions xmlns:bpmn="http://www.omg.org/spec/BPMN/20100524/MODEL" xmlns:bpmndi="http://www.omg.org/spec/BPMN/20100524/DI" xmlns:dc="http://www.omg.org/spec/DD/20100524/DC" xmlns:camunda="http://camunda.org/schema/1.0/bpmn" xmlns:di="http://www.omg.org/spec/DD/20100524/DI" id="Definitions_bd39673" targetNamespace="http://bpmn.io/schema/bpmn" exporter="Camunda Modeler" exporterVersion="4.2.0">
   <bpmn:process id="Process_fe6205f" isExecutable="true">
     <bpmn:startEvent id="StartEvent_1">
       <bpmn:outgoing>Flow_0scd96e</bpmn:outgoing>
@@ -8,24 +8,25 @@
     <bpmn:userTask id="Activity_EmailForm" name="Email Form" camunda:formKey="email_form">
       <bpmn:extensionElements>
         <camunda:formData>
-          <camunda:formField id="subject" label="'Subject'"  type="string" defaultValue="&#39;My Email Subject&#39;">
+          <camunda:formField id="subject" label="&#39;Subject&#39;" type="string" defaultValue="&#39;My Email Subject&#39;">
             <camunda:validation>
               <camunda:constraint name="required" config="true" />
             </camunda:validation>
           </camunda:formField>
-          <camunda:formField id="recipients" label="'Enter Email'"  type="string" defaultValue="&#39;user@example.com&#39;">
+          <camunda:formField id="recipients" label="&#39;Enter Email&#39;" type="string" defaultValue="&#39;user@example.com&#39;">
             <camunda:validation>
               <camunda:constraint name="required" config="true" />
             </camunda:validation>
           </camunda:formField>
-          <camunda:formField id="cc" label="'CC'"  type="string" />
-          <camunda:formField id="bcc" label="'Bcc'"  type="string" />
-          <camunda:formField id="reply_to" label="'Reply To'"  type="string" />
-          <camunda:formField id="doc_code" label="'Doc Code'"  type="string">
+          <camunda:formField id="cc" label="&#39;CC&#39;" type="string" />
+          <camunda:formField id="bcc" label="&#39;Bcc&#39;" type="string" />
+          <camunda:formField id="reply_to" label="&#39;Reply To&#39;" type="string" />
+          <camunda:formField id="doc_code" label="&#39;Doc Code&#39;" type="string">
             <camunda:properties>
               <camunda:property id="repeat" value="doc_codes" />
             </camunda:properties>
           </camunda:formField>
+          <camunda:formField id="name" label="&#39;Name&#39;" type="string" />
         </camunda:formData>
       </bpmn:extensionElements>
       <bpmn:incoming>Flow_0scd96e</bpmn:incoming>
@@ -55,12 +56,14 @@ if not 'bcc' in globals():
     bcc=None
 if not 'reply_to' in globals():
     reply_to=None
+if not 'name' in globals():
+   name = None
 
 attachments = []
 if 'doc_codes' in globals():
     for item in globals()['doc_codes']:
         attachments.append(item['doc_code'])
-email(subject=subject, recipients=recipients, cc=cc, bcc=bcc, reply_to=reply_to, attachments=attachments)</bpmn:script>
+email_model = email(subject=subject, recipients=recipients, cc=cc, bcc=bcc, reply_to=reply_to, attachments=attachments, name=name)</bpmn:script>
     </bpmn:scriptTask>
     <bpmn:sequenceFlow id="Flow_0xrm7iw" sourceRef="Activity_SendEmail" targetRef="Activity_1lnjeej" />
     <bpmn:sequenceFlow id="Flow_0wv0swo" sourceRef="Activity_1lnjeej" targetRef="Event_EndEvent" />


### PR DESCRIPTION
 *** Requires the file-refactor code ***

Add an optional `name` parameter to the email script.
Add `name` column to the `email` table to store the new name value