### PR TITLE
Bug/move workflow spec issue #744

### DIFF
--- a/crc/api/workflow.py
+++ b/crc/api/workflow.py
@@ -133,6 +133,7 @@ def update_workflow_specification(spec_id, body):
     if spec_id is None:
         raise ApiError('unknown_spec', 'Please provide a valid Workflow Spec ID.')
     spec = spec_service.get_spec(spec_id)
+    old_category_id = spec.category_id
 
     if spec is None:
         raise ApiError('unknown_study', 'The spec "' + spec_id + '" is not recognized.')
@@ -145,7 +146,7 @@ def update_workflow_specification(spec_id, body):
     if body['library'] is True or body['standalone'] is True:
         body['category_id'] = None
     spec = WorkflowSpecInfoSchema().load(body)
-    spec_service.update_spec(spec)
+    spec_service.update_spec(spec, old_category_id)
     return WorkflowSpecInfoSchema().dump(spec)
 
 

--- a/crc/services/file_system_service.py
+++ b/crc/services/file_system_service.py
@@ -1,5 +1,6 @@
 import datetime
 import os
+import shutil
 from typing import List
 
 import pytz
@@ -140,3 +141,14 @@ class FileSystemService(object):
         last_modified = FileSystemService._last_modified(item.path)
         return File.from_file_system(item.name, file_type, content_type, last_modified, file_size)
 
+    def move_spec_files(self, spec, old_category):
+        new_spec_path = self.workflow_path(spec)
+        old_category_path = self.category_path(old_category)
+        old_spec_path = os.path.join(old_category_path, spec.id)
+        os.makedirs(new_spec_path, exist_ok=True)
+
+        file_names = os.listdir(old_spec_path)
+        for file_name in file_names:
+            shutil.move(os.path.join(old_spec_path, file_name), new_spec_path)
+
+        os.rmdir(old_spec_path)

--- a/crc/services/workflow_spec_service.py
+++ b/crc/services/workflow_spec_service.py
@@ -25,7 +25,9 @@ class WorkflowSpecService(FileSystemService):
         spec.display_order = display_order
         self.update_spec(spec)
 
-    def update_spec(self, spec:WorkflowSpecInfo):
+    def update_spec(self, spec: WorkflowSpecInfo, old_category_id=None):
+        if old_category_id is not None and spec.category_id != old_category_id:
+            FileSystemService().move_spec_files(spec, old_category_id)
         spec_path = self.workflow_path(spec)
         if spec.is_master_spec or spec.library or spec.standalone:
             spec.category_id = ""


### PR DESCRIPTION
We were not moving workflow specs when their category changed.

- Create a method in that moves WorkflowSpecs to a new directory (category)
- Use the new method when updating a workflow spec, if we are changing the category
- Rewrite the test around updating workflow specs