### PR TITLE
Chore/email attachment info #758

### DIFF
--- a/crc/models/email.py
+++ b/crc/models/email.py
@@ -1,5 +1,4 @@
-from flask_marshmallow.sqla import SQLAlchemyAutoSchema
-from marshmallow import EXCLUDE, INCLUDE
+from marshmallow import fields
 from sqlalchemy import func
 
 from crc import db, ma
@@ -21,6 +20,20 @@ class EmailModel(db.Model):
     workflow_spec_id = db.Column(db.String, nullable=True)
     study = db.relationship(StudyModel)
     name = db.Column(db.String)
+    doc_codes = db.relationship("EmailDocCodesModel")
+
+
+class EmailDocCodesModel(db.Model):
+    __tablename__ = 'email_doc_codes'
+    id = db.Column(db.Integer, primary_key=True)
+    email_id = db.Column(db.Integer, db.ForeignKey(EmailModel.id))
+    doc_code = db.Column(db.String)
+
+
+class EmailDocCodesSchema(ma.Schema):
+    class Meta:
+        model = EmailDocCodesModel
+        fields = ["doc_code"]
 
 
 class EmailModelSchema(ma.Schema):
@@ -28,4 +41,12 @@ class EmailModelSchema(ma.Schema):
     class Meta:
         model = EmailModel
         fields = ["id", "subject", "sender", "recipients", "cc", "bcc", "content",
-                  "study_id", "timestamp", "workflow_spec_id", "name"]
+                  "study_id", "timestamp", "workflow_spec_id", "name", "doc_codes"]
+    doc_codes = fields.Method('get_doc_codes', dump_only=True)
+
+    @staticmethod
+    def get_doc_codes(email):
+        doc_codes = []
+        for doc_code in email.doc_codes:
+            doc_codes.append(doc_code.doc_code)
+        return doc_codes

--- a/crc/scripts/email.py
+++ b/crc/scripts/email.py
@@ -248,7 +248,8 @@ email(subject="My Subject", recipients="user@example.com", attachments=[('Study_
                             files.append({'id': file.id,
                                           'name': file.name,
                                           'type': CONTENT_TYPES[file.type],
-                                          'data': file.data})
+                                          'data': file.data,
+                                          'doc_code': doc_code})
                 else:
                     raise ApiError(code='bad_doc_code',
                                    message=f'The doc_code {doc_code} is not valid.')

--- a/crc/scripts/email.py
+++ b/crc/scripts/email.py
@@ -43,6 +43,8 @@ Examples:
 email(subject="My Subject", recipients=["dhf8r@virginia.edu", pi.email, 'associated'])
 email(subject="My Subject", recipients="user@example.com", cc='associated', bcc='test_user@example.com)
 email(subject="My Subject", recipients="user@example.com", reply_to="reply_to@example.com")
+email(subject="My Subject", recipients="user@example.com", attachments='Study_App_Doc')
+email(subject="My Subject", recipients="user@example.com", attachments=['Study_App_Doc', Study_Protocol_Document])
 email(subject="My Subject", recipients="user@example.com", attachments=('Study_App_Doc', []))
 email(subject="My Subject", recipients="user@example.com", attachments=[('Study_App_Doc', ['some_file_name']),('Study_Protocol_Document',[])])
 email(subject="My Subject", recipients="user@example.com", attachments=[('Study_App_Doc', ['some_file_name']), 'Study_Protocol_Document'])

--- a/migrations/versions/a323a4d14bd7_email_doc_codes.py
+++ b/migrations/versions/a323a4d14bd7_email_doc_codes.py
@@ -1,0 +1,33 @@
+"""Store attachment doc codes for emails
+
+Revision ID: a323a4d14bd7
+Revises: 546575fa21a8
+Create Date: 2022-06-15 12:24:39.298593
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'a323a4d14bd7'
+down_revision = '546575fa21a8'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        'email_doc_codes',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('email_id', sa.Integer(), nullable=False),
+        sa.Column('doc_codes', sa.String()),
+        sa.ForeignKeyConstraint(['email_id'], ['email.id'], ),
+        sa.PrimaryKeyConstraint('id')
+    )
+    op.create_foreign_key('email_id_key', 'email_doc_codes', 'email', ['email_id'], ['id'])
+
+
+def downgrade():
+    op.drop_constraint('email_id_key', 'email_doc_codes', type_='foreignkey')
+    op.drop_table('email_doc_codes')

--- a/tests/scripts/test_get_email_data.py
+++ b/tests/scripts/test_get_email_data.py
@@ -2,6 +2,7 @@ from tests.base_test import BaseTest
 from crc import mail, session
 from crc.models.workflow import WorkflowModel
 from crc.services.email_service import EmailService
+from crc.services.user_file_service import UserFileService
 
 
 class TestGetEmailData(BaseTest):
@@ -36,6 +37,7 @@ class TestGetEmailData(BaseTest):
             self.assertIn('email_data', data)
             email_data = data['email_data']
             self.assertEqual(1, len(email_data))
+            self.assertIn('doc_codes', email_data[0])
             self.assertEqual('My Email Subject', email_data[0]['subject'])
             self.assertEqual('sender@example.com', email_data[0]['sender'])
             self.assertEqual('[\'joe@example.com\']', email_data[0]['recipients'])
@@ -80,12 +82,72 @@ class TestGetEmailData(BaseTest):
             self.assertIn('email_data', data)
             email_data = data['email_data']
             self.assertEqual(2, len(email_data))
+            self.assertIn('doc_codes', email_data[0])
             self.assertEqual('My Email Subject', email_data[0]['subject'])
             self.assertEqual('sender@example.com', email_data[0]['sender'])
             self.assertEqual('[\'joe@example.com\']', email_data[0]['recipients'])
             self.assertEqual('My Email Name', email_data[0]['name'])
 
+            self.assertIn('doc_codes', email_data[1])
             self.assertEqual('My Other Email Subject', email_data[1]['subject'])
             self.assertEqual('sender2@example.com', email_data[1]['sender'])
             self.assertEqual('[\'joanne@example.com\']', email_data[1]['recipients'])
             self.assertEqual('My Email Name', email_data[1]['name'])
+
+    def test_get_email_data_with_attachments(self):
+        self.create_reference_document()
+        irb_code_1 = 'Study_App_Doc'
+        irb_code_2 = 'Study_Protocol_Document'
+
+        workflow = self.create_workflow('get_email_data')
+        workflow_api = self.get_workflow_api(workflow)
+        first_task = workflow_api.next_task
+
+        UserFileService.add_workflow_file(workflow_id=workflow.id,
+                                          task_spec_name=first_task.name,
+                                          name="something.png", content_type="text",
+                                          binary_data=b'1234', irb_doc_code=irb_code_1)
+        UserFileService.add_workflow_file(workflow_id=workflow.id,
+                                          task_spec_name=first_task.name,
+                                          name="another.png", content_type="text",
+                                          binary_data=b'67890', irb_doc_code=irb_code_1)
+        UserFileService.add_workflow_file(workflow_id=workflow.id,
+                                          task_spec_name=first_task.name,
+                                          name="anything.png", content_type="text",
+                                          binary_data=b'5678', irb_doc_code=irb_code_2)
+        attachment_files = [
+            {'id': 1, 'name': 'something.png', 'type': 'image/png', 'data': b'1234', 'doc_code': 'Study_App_Doc'},
+            {'id': 2, 'name': 'another.png', 'type': 'image/png', 'data': b'67890', 'doc_code': 'Study_App_Doc'},
+            {'id': 3, 'name': 'anything.png', 'type': 'image/png', 'data': b'5678', 'doc_code': 'Study_Protocol_Document'}
+        ]
+
+        with mail.record_messages() as outbox:
+            # Send an email we can use for get_email_data
+            email_model_one = EmailService.add_email(subject='My Email Subject',
+                                                     sender='sender@example.com',
+                                                     recipients=['joe@example.com'],
+                                                     name='My Email Name',
+                                                     content='asdf',
+                                                     content_html=None,
+                                                     study_id=workflow.study_id,
+                                                     workflow_spec_id=workflow.workflow_spec_id,
+                                                     attachment_files=attachment_files)
+
+            workflow_api = self.get_workflow_api(workflow)
+            task = workflow_api.next_task
+
+            # Run workflow with get_email_data
+            workflow_api = self.complete_form(workflow, task, {'email_id': email_model_one.id})
+            task = workflow_api.next_task
+            data = task.data
+
+            self.assertIn('email_data', data)
+            email_data = data['email_data']
+            self.assertEqual(1, len(email_data))
+
+            email = email_data[0]
+            self.assertIn('doc_codes', email)
+            doc_codes = email['doc_codes']
+            self.assertEqual(2, len(doc_codes))
+            self.assertIn('Study_App_Doc', doc_codes)
+            self.assertIn('Study_Protocol_Document', doc_codes)


### PR DESCRIPTION
Persist doc_code information when we add attachments to email messages, and
Return the doc_code information in the get_email_info script

 *** This includes a migration ***