### PR TITLE
Bug/restart issue 770

### DIFF
--- a/crc/models/api_models.py
+++ b/crc/models/api_models.py
@@ -188,6 +188,7 @@ class NavigationItemSchema(ma.Schema):
         item.children = children
         return item
 
+
 class DocumentDirectorySchema(ma.Schema):
     level = marshmallow.fields.String()
     file = marshmallow.fields.Nested(FileSchema)
@@ -212,7 +213,7 @@ class DocumentDirectory(object):
 class WorkflowApi(object):
     def __init__(self, id, status, next_task, navigation,
                  workflow_spec_id,
-                 last_updated, is_review, title, study_id, state, is_admin_workflow=False):
+                 last_updated, is_review, title, study_id, state, user_id, is_admin_workflow=False):
         self.id = id
         self.status = status
         self.next_task = next_task  # The next task that requires user input.
@@ -223,6 +224,7 @@ class WorkflowApi(object):
         self.is_review = is_review
         self.study_id = study_id or ''
         self.state = state
+        self.user_id = user_id
         self.is_admin_workflow = is_admin_workflow
 
 
@@ -231,7 +233,7 @@ class WorkflowApiSchema(ma.Schema):
         model = WorkflowApi
         fields = ["id", "status", "next_task", "navigation",
                   "workflow_spec_id", "total_tasks", "completed_tasks",
-                  "last_updated", "is_review", "title", "study_id", "state", "is_admin_workflow"]
+                  "last_updated", "is_review", "title", "study_id", "state", "user_id", "is_admin_workflow"]
         unknown = INCLUDE
 
     status = EnumField(WorkflowStatus)
@@ -243,7 +245,7 @@ class WorkflowApiSchema(ma.Schema):
     def make_workflow(self, data, **kwargs):
         keys = ['id', 'status', 'next_task', 'navigation',
                 'workflow_spec_id',
-                "last_updated", "is_review", "title", "study_id", "state", "is_admin_workflow"]
+                "last_updated", "is_review", "title", "study_id", "state", "user_id", "is_admin_workflow"]
         filtered_fields = {key: data[key] for key in keys}
         filtered_fields['next_task'] = TaskSchema().make_task(data['next_task'])
         return WorkflowApi(**filtered_fields)

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -685,6 +685,12 @@ class WorkflowService(object):
         return navigation
 
     @staticmethod
+    def get_workflow_user_id(workflow_id):
+        user_id = db.session.query(WorkflowModel.user_id).\
+            filter(WorkflowModel.id == workflow_id).scalar()
+        return user_id
+
+    @staticmethod
     def processor_to_workflow_api(processor: WorkflowProcessor, next_task=None):
         """Returns an API model representing the state of the current workflow, if requested, and
         possible, next_task is set to the current_task."""
@@ -693,8 +699,10 @@ class WorkflowService(object):
         spec_service = WorkflowSpecService()
         spec = spec_service.get_spec(processor.workflow_spec_id)
         is_admin_workflow = WorkflowService.is_admin_workflow(processor.workflow_spec_id)
+        workflow_id = processor.get_workflow_id()
+        user_id = WorkflowService.get_workflow_user_id(workflow_id)
         workflow_api = WorkflowApi(
-            id=processor.get_workflow_id(),
+            id=workflow_id,
             status=processor.get_status(),
             next_task=None,
             navigation=WorkflowService.get_navigation(processor),
@@ -704,6 +712,7 @@ class WorkflowService(object):
             title=spec.display_name,
             study_id=processor.workflow_model.study_id or None,
             state=processor.workflow_model.state,
+            user_id=user_id,
             is_admin_workflow=is_admin_workflow
         )
         if not next_task:  # The Next Task can be requested to be a certain task, useful for parallel tasks.

--- a/tests/base_test.py
+++ b/tests/base_test.py
@@ -306,6 +306,7 @@ class BaseTest(unittest.TestCase):
                           content_type="application/json")
         self.assert_success(rv)
         json_data = json.loads(rv.get_data(as_text=True))
+        json_data['user_id'] = user.uid
         workflow_api = WorkflowApiSchema().load(json_data)
         return workflow_api
 
@@ -361,6 +362,7 @@ class BaseTest(unittest.TestCase):
         json_data = json.loads(rv.get_data(as_text=True))
 
         # Assure task events are updated on the model
+        json_data['user_id'] = user_uid
         workflow = WorkflowApiSchema().load(json_data)
 
         # Assure a record exists in the Task Events

--- a/tests/test_multi_instance_tasks_api.py
+++ b/tests/test_multi_instance_tasks_api.py
@@ -41,6 +41,7 @@ class TestMultiinstanceTasksApi(BaseTest):
 
     @patch('crc.services.protocol_builder.requests.get')
     def test_parallel_multi_instance(self, mock_get):
+        user = self.create_user()
 
         # Assure we get nine investigators back from the API Call, as set in the investigators.json file.
         app.config['PB_ENABLED'] = True
@@ -63,10 +64,11 @@ class TestMultiinstanceTasksApi(BaseTest):
         for i in random.sample(range(5), 5):
             task_id = ready_items[i].task_id
             rv = self.app.put('/v1.0/workflow/%i/task/%s/set_token' % (workflow.id, task_id),
-                              headers=self.logged_in_headers(),
+                              headers=self.logged_in_headers(user),
                               content_type="application/json")
             self.assert_success(rv)
             json_data = json.loads(rv.get_data(as_text=True))
+            json_data['user_id'] = user.uid
             workflow_api = WorkflowApiSchema().load(json_data)
             data = workflow_api.next_task.data
             data['investigator']['email'] = "dhf8r@virginia.edu"

--- a/tests/test_tasks_api.py
+++ b/tests/test_tasks_api.py
@@ -330,6 +330,7 @@ class TestTasksApi(BaseTest):
         self.assertEqual(WorkflowStatus.complete, workflow_api.status)
 
     def test_update_task_resets_token(self):
+        user = self.create_user()
         workflow = self.create_workflow('exclusive_gateway')
 
         # Start the workflow.
@@ -350,10 +351,11 @@ class TestTasksApi(BaseTest):
 
         # Make the old task the current task.
         rv = self.app.put('/v1.0/workflow/%i/task/%s/set_token' % (workflow.id, first_task.id),
-                          headers=self.logged_in_headers(),
+                          headers=self.logged_in_headers(user),
                           content_type="application/json")
         self.assert_success(rv)
         json_data = json.loads(rv.get_data(as_text=True))
+        json_data['user_id'] = user.uid
         workflow_api = WorkflowApiSchema().load(json_data)
 
         # Assure the Next Task is the one we just reset the token to be on.


### PR DESCRIPTION
*** This supports a frontend PR with the same name ***

We now pass workflow.user_id in WorkflowApi
This helps us decide what to show in the frontend UI

WorkflowApi is just an object, so there is no migration

Had to fix a couple tests where we call WorkflowApi directly.