### PR TITLE
Fix to prevent continuing Sentry "Working outside of application context" error

### DIFF
--- a/crc/models/file.py
+++ b/crc/models/file.py
@@ -20,9 +20,11 @@ class FileType(enum.Enum):
     dmn = "dmn"
     doc = "doc"
     docx = "docx"
+    eml = "eml"
     gif = 'gif'
     jpg = 'jpg'
     md = 'md'
+    msg = 'msg'
     pdf = 'pdf'
     png = 'png'
     ppt = 'ppt'
@@ -43,9 +45,11 @@ CONTENT_TYPES = {
     "dmn": "text/xml",
     "doc": "application/msword",
     "docx":  "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "eml": "application/octet-stream",
     "gif": "image/gif",
     "jpg": "image/jpeg",
     "md": "text/plain",
+    "msg": "application/vnd.ms-outlook",
     "pdf": "application/pdf",
     "png": "image/png",
     "ppt": "application/vnd.ms-powerpoint",

--- a/crc/services/workflow_service.py
+++ b/crc/services/workflow_service.py
@@ -139,30 +139,31 @@ class WorkflowService(object):
         return workflow_url
 
     def process_erroring_workflows(self):
-        workflows = self.get_erroring_workflows()
-        if len(workflows) > 0:
-            workflow_urls = []
-            if len(workflows) == 1:
-                workflow = workflows[0]
-                workflow_url_link = self.get_workflow_url(workflow)
-                workflow_urls.append(workflow_url_link)
-                message = 'There is one workflow in an error state.'
-                message += f'\n You can restart the workflow at {workflow_url_link}.'
-            else:
-                message = f'There are {len(workflows)} workflows in an error state.'
-                message += '\nYou can restart the workflows at these URLs:'
-                for workflow in workflows:
+        with app.app_context():    
+            workflows = self.get_erroring_workflows()
+            if len(workflows) > 0:
+                workflow_urls = []
+                if len(workflows) == 1:
+                    workflow = workflows[0]
                     workflow_url_link = self.get_workflow_url(workflow)
                     workflow_urls.append(workflow_url_link)
-                    message += f'\n{workflow_url_link}'
-
-            with push_scope() as scope:
-                scope.user = {"urls": workflow_urls}
-                scope.set_extra("workflow_urls", workflow_urls)
-                # this sends a message through sentry
-                capture_message(message)
-            # We return message so we can use it in a test
-            return message
+                    message = 'There is one workflow in an error state.'
+                    message += f'\n You can restart the workflow at {workflow_url_link}.'
+                else:
+                    message = f'There are {len(workflows)} workflows in an error state.'
+                    message += '\nYou can restart the workflows at these URLs:'
+                    for workflow in workflows:
+                        workflow_url_link = self.get_workflow_url(workflow)
+                        workflow_urls.append(workflow_url_link)
+                        message += f'\n{workflow_url_link}'
+    
+                with push_scope() as scope:
+                    scope.user = {"urls": workflow_urls}
+                    scope.set_extra("workflow_urls", workflow_urls)
+                    # this sends a message through sentry
+                    capture_message(message)
+                # We return message so we can use it in a test
+                return message
 
     @staticmethod
     def test_spec(spec_id, validate_study_id=None, test_until=None, required_only=False):


### PR DESCRIPTION
Sentry has been reporting a "Working outside of application context" error in Slack. The code within process_erroring_workflows is now now wrapped "with app.app_context():", which should resolve the issue.
